### PR TITLE
[WIP] Support for Prophecy

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -18,3 +18,11 @@ services:
 		class: PHPStan\Type\PHPUnit\MockBuilderDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: PHPStan\Type\Prophecy\ProphetDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: PHPStan\Type\Prophecy\ObjectProphecyDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Type/Prophecy/ObjectProphecyDynamicReturnTypeExtension.php
+++ b/src/Type/Prophecy/ObjectProphecyDynamicReturnTypeExtension.php
@@ -6,13 +6,14 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
+use Prophecy\Prophecy\ObjectProphecy;
 
 class ObjectProphecyDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
 	public function getClass(): string
 	{
-		return \PHPUnit_Framework_MockObject_MockBuilder::class;
+		return ObjectProphecy::class;
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool

--- a/src/Type/Prophecy/ObjectProphecyDynamicReturnTypeExtension.php
+++ b/src/Type/Prophecy/ObjectProphecyDynamicReturnTypeExtension.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Prophecy;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Type;
+
+class ObjectProphecyDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return \PHPUnit_Framework_MockObject_MockBuilder::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return true;
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		if ($methodReflection->getName() === 'reveal') {
+			return $scope->getType($methodCall->var);
+		}
+
+		return $methodReflection->getReturnType();
+	}
+
+}

--- a/src/Type/Prophecy/ObjectProphecyDynamicReturnTypeExtension.php
+++ b/src/Type/Prophecy/ObjectProphecyDynamicReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Prophecy;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Prophecy\Prophecy\ObjectProphecy;
 
@@ -24,7 +25,11 @@ class ObjectProphecyDynamicReturnTypeExtension implements \PHPStan\Type\DynamicM
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
 		if ($methodReflection->getName() === 'reveal') {
-			return $scope->getType($methodCall->var);
+			$calledOnType = $scope->getType($methodCall->var);
+
+			if ($calledOnType instanceof ObjectProphecyType) {
+				return new ObjectType($calledOnType->getMockedClass());
+			}
 		}
 
 		return $methodReflection->getReturnType();

--- a/src/Type/Prophecy/ObjectProphecyType.php
+++ b/src/Type/Prophecy/ObjectProphecyType.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Prophecy;
+
+use Prophecy\Prophecy\ObjectProphecy;
+
+class ObjectProphecyType extends \PHPStan\Type\ObjectType
+{
+
+	/**
+	 * @var string
+	 */
+	private $mockedClass;
+
+	public function __construct(string $mockedClass)
+	{
+		parent::__construct(ObjectProphecy::class);
+		$this->mockedClass = $mockedClass;
+	}
+
+	public function getMockedClass(): string
+	{
+		return $this->mockedClass;
+	}
+
+	public function describe(): string
+	{
+		return sprintf('%s<%s>', parent::describe(), $this->mockedClass);
+	}
+
+}

--- a/src/Type/Prophecy/ProphetDynamicReturnTypeExtension.php
+++ b/src/Type/Prophecy/ProphetDynamicReturnTypeExtension.php
@@ -6,13 +6,14 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
+use Prophecy\Prophet;
 
 class ProphetDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
 	public function getClass(): string
 	{
-		return \PHPUnit_Framework_MockObject_MockBuilder::class;
+		return Prophet::class;
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool

--- a/src/Type/Prophecy/ProphetDynamicReturnTypeExtension.php
+++ b/src/Type/Prophecy/ProphetDynamicReturnTypeExtension.php
@@ -6,14 +6,14 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Type;
-use Prophecy\Prophet;
+use PHPUnit\Framework\TestCase;
 
 class ProphetDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
 
 	public function getClass(): string
 	{
-		return Prophet::class;
+		return TestCase::class;
 	}
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool

--- a/src/Type/Prophecy/ProphetDynamicReturnTypeExtension.php
+++ b/src/Type/Prophecy/ProphetDynamicReturnTypeExtension.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Prophecy;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Type;
+
+class ProphetDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return \PHPUnit_Framework_MockObject_MockBuilder::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'prophesize';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		if (count($methodCall->args) === 0) {
+			return $methodReflection->getReturnType();
+		}
+		$arg = $methodCall->args[0]->value;
+		if (!($arg instanceof \PhpParser\Node\Expr\ClassConstFetch)) {
+			return $methodReflection->getReturnType();
+		}
+
+		$class = $arg->class;
+		if (!($class instanceof \PhpParser\Node\Name)) {
+			return $methodReflection->getReturnType();
+		}
+
+		$class = (string) $class;
+		if ($class === 'static') {
+			return $methodReflection->getReturnType();
+		}
+
+		if ($class === 'self') {
+			$class = $scope->getClassReflection()->getName();
+		}
+
+		return new ObjectProphecyType($class);
+	}
+
+}


### PR DESCRIPTION
Reading https://github.com/phpstan/phpstan/issues/134 and wanting to try PHPStan 0.9, I wanted to try to write the extension to make PHPStan and Prophecy work along.

I'm not an expert on PHPStan internals, so I started working on this copypasting from the MockBuilder classes, and I reached a point where the `reveal()` method is no longer an issue for PHPStan! :tada: 

Now, I need to tackle the issues reported when defining the expectation on a mock, and that's a lot trickier!

Scenario:

```php
$mock = $this->prophesize(SUTClass::class);
$mock->methodA(...)
    ->should...()
    ->will...();

```
Basically you can call on the mock any method of it's base class (`ObjectProphecy`) but also any method of the mocked class (`methodA`); the problem is that those methods will accept the same stuff defined bu the original signature OR `TokenInterface`s from Prophecy, OR a mix of that.; also, it will return a `MethodProphecy` every time.

How we should tackle this?