### PR TITLE
Add missing methods that generate mocks

### DIFF
--- a/src/Type/PHPUnit/CreateMockDynamicReturnTypeExtension.php
+++ b/src/Type/PHPUnit/CreateMockDynamicReturnTypeExtension.php
@@ -16,6 +16,8 @@ class CreateMockDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMetho
 	private $methods = [
 		'createMock' => 0,
 		'createConfiguredMock' => 0,
+		'createPartialMock' => 0,
+		'createTestProxy' => 0,
 		'getMockForAbstractClass' => 0,
 		'getMockFromWsdl' => 1,
 	];


### PR DESCRIPTION
Some methods were missing, and when used `phpstan` doesn't work properly. It shows errors like:

```sh
Property MyTest::$property (MockedClass&PHPUnit\Framework\MockObject\MockObject) does not accept PHPUnit\Framework\MockObject\MockObject. 
```

This PR fixes it, but I didn't add any test (since the repo doesn't have any)