### PR TITLE
Strict and opinionated rules for PHPUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ It also contains this framework-specific rule (can be enabled separately):
 
 * Check that both values passed to `assertSame()` method are of the same type.
 
-It also contains this strict framework-specific rule (can be enabled separately):
+It also contains this strict framework-specific rules (can be enabled separately):
 
+* Check that you are not using `assertSame()` with `true` as expected value. `assertTrue()` should be used instead.
+* Check that you are not using `assertSame()` with `false` as expected value. `assertFalse()` should be used instead.
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
 
 ## How to document mock objects in phpDocs?

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ It also contains this framework-specific rule (can be enabled separately):
 
 * Check that both values passed to `assertSame()` method are of the same type.
 
+It also contains this strict framework-specific rule (can be enabled separately):
+
+* Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
+
 ## How to document mock objects in phpDocs?
 
 If you need to configure the mock even after you assign it to a property or return it from a method, you should add `PHPUnit_Framework_MockObject_MockObject` to the phpDoc:
@@ -80,4 +84,10 @@ To perform framework-specific checks, include also this file:
 
 ```
 	- vendor/phpstan/phpstan-phpunit/rules.neon
+```
+
+To perform addition strict PHPUnit checks, include also this file:
+
+```
+	- vendor/phpstan/phpstan-phpunit/strictRules.neon
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It also contains this strict framework-specific rules (can be enabled separately
 * Check that you are not using `assertSame()` with `true` as expected value. `assertTrue()` should be used instead.
 * Check that you are not using `assertSame()` with `false` as expected value. `assertFalse()` should be used instead.
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
+* Check that you are not using `assertSame()` with `count($variable)` as second parameter. `assertCount($variable)` should be used instead.
 
 ## How to document mock objects in phpDocs?
 

--- a/build.xml
+++ b/build.xml
@@ -42,7 +42,6 @@
 			<arg value="--extensions=php"/>
 			<arg value="--encoding=utf-8"/>
 			<arg value="--tab-width=4"/>
-			<arg value="--ignore=tests/*/data"/>
 			<arg value="-sp"/>
 			<arg path="src"/>
 			<arg path="tests"/>
@@ -59,7 +58,6 @@
 			<arg value="--extensions=php"/>
 			<arg value="--encoding=utf-8"/>
 			<arg value="--tab-width=4"/>
-			<arg value="--ignore=tests/*/data"/>
 			<arg value="-sp"/>
 			<arg path="src"/>
 			<arg path="tests"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -36,4 +36,5 @@
 			<property name="enableVoidTypeHint" type="false" />
 		</properties>
 	</rule>
+	<exclude-pattern>tests/*/data</exclude-pattern>
 </ruleset>

--- a/src/Rules/PHPUnit/AssertRuleHelper.php
+++ b/src/Rules/PHPUnit/AssertRuleHelper.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
+
+class AssertRuleHelper
+{
+
+	/**
+	 * @param \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return bool
+	 */
+	public static function isMethodOrStaticCallOnTestCase(Node $node, Scope $scope): bool
+	{
+		$testCaseType = new ObjectType(\PHPUnit\Framework\TestCase::class);
+		if ($node instanceof Node\Expr\MethodCall) {
+			$calledOnType = $scope->getType($node->var);
+		} elseif ($node instanceof Node\Expr\StaticCall) {
+			if ($node->class instanceof Node\Name) {
+				$class = (string) $node->class;
+				if (in_array(
+					strtolower($class),
+					[
+						'self',
+						'static',
+						'parent',
+					],
+					true
+				)) {
+					$calledOnType = new ObjectType($scope->getClassReflection()->getName());
+				} else {
+					$calledOnType = new ObjectType($class);
+				}
+			} else {
+				$calledOnType = $scope->getType($node->class);
+			}
+		} else {
+			return false;
+		}
+
+		if (!$testCaseType->isSuperTypeOf($calledOnType)->yes()) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\FalseBooleanType;
+use PHPStan\Type\TrueBooleanType;
+
+class AssertSameBooleanExpectedRule implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\NodeAbstract::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!AssertRuleHelper::isMethodOrStaticCallOnTestCase($node, $scope)) {
+			return [];
+		}
+
+		if (count($node->args) < 2) {
+			return [];
+		}
+		if (!is_string($node->name) || strtolower($node->name) !== 'assertsame') {
+			return [];
+		}
+
+		$leftType = $scope->getType($node->args[0]->value);
+
+		if ($leftType instanceof TrueBooleanType) {
+			return [
+				'You should use assertTrue() instead of assertSame() when expecting "true"',
+			];
+		}
+
+		if ($leftType instanceof FalseBooleanType) {
+			return [
+				'You should use assertFalse() instead of assertSame() when expecting "false"',
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/src/Rules/PHPUnit/AssertSameDifferentTypesRule.php
+++ b/src/Rules/PHPUnit/AssertSameDifferentTypesRule.php
@@ -4,7 +4,6 @@ namespace PHPStan\Rules\PHPUnit;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\ObjectType;
 
 class AssertSameDifferentTypesRule implements \PHPStan\Rules\Rule
 {
@@ -21,33 +20,7 @@ class AssertSameDifferentTypesRule implements \PHPStan\Rules\Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		$testCaseType = new ObjectType(\PHPUnit\Framework\TestCase::class);
-		if ($node instanceof Node\Expr\MethodCall) {
-			$calledOnType = $scope->getType($node->var);
-		} elseif ($node instanceof Node\Expr\StaticCall) {
-			if ($node->class instanceof Node\Name) {
-				$class = (string) $node->class;
-				if (in_array(
-					strtolower($class),
-					[
-						'self',
-						'static',
-						'parent',
-					],
-					true
-				)) {
-					$calledOnType = new ObjectType($scope->getClassReflection()->getName());
-				} else {
-					$calledOnType = new ObjectType($class);
-				}
-			} else {
-				$calledOnType = $scope->getType($node->class);
-			}
-		} else {
-			return [];
-		}
-
-		if (!$testCaseType->isSuperTypeOf($calledOnType)->yes()) {
+		if (!AssertRuleHelper::isMethodOrStaticCallOnTestCase($node, $scope)) {
 			return [];
 		}
 

--- a/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\NullType;
+
+class AssertSameNullExpectedRule implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\NodeAbstract::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!AssertRuleHelper::isMethodOrStaticCallOnTestCase($node, $scope)) {
+			return [];
+		}
+
+		if (count($node->args) < 2) {
+			return [];
+		}
+		if (!is_string($node->name) || strtolower($node->name) !== 'assertsame') {
+			return [];
+		}
+
+		$leftType = $scope->getType($node->args[0]->value);
+
+		if ($leftType instanceof NullType) {
+			return [
+				'You should use assertNull() instead of assertSame(null, $actual).',
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/src/Rules/PHPUnit/AssertSameWithCountRule.php
+++ b/src/Rules/PHPUnit/AssertSameWithCountRule.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+
+class AssertSameWithCountRule implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\NodeAbstract::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[] errors
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!AssertRuleHelper::isMethodOrStaticCallOnTestCase($node, $scope)) {
+			return [];
+		}
+
+		if (count($node->args) < 2) {
+			return [];
+		}
+		if (!is_string($node->name) || strtolower($node->name) !== 'assertsame') {
+			return [];
+		}
+
+		$right = $node->args[1]->value;
+
+		if (
+			$right instanceof Node\Expr\FuncCall
+			&& $right->name instanceof Node\Name
+			&& strtolower($right->name->toString()) === 'count'
+		) {
+			return [
+				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).',
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/strictRules.neon
+++ b/strictRules.neon
@@ -1,0 +1,5 @@
+services:
+	-
+		class: PHPStan\Rules\PHPUnit\AssertSameNullExpectedRule
+		tags:
+			- phpstan.rules.rule

--- a/strictRules.neon
+++ b/strictRules.neon
@@ -7,3 +7,7 @@ services:
 		class: PHPStan\Rules\PHPUnit\AssertSameNullExpectedRule
 		tags:
 			- phpstan.rules.rule
+	-
+		class: PHPStan\Rules\PHPUnit\AssertSameWithCountRule
+		tags:
+			- phpstan.rules.rule

--- a/strictRules.neon
+++ b/strictRules.neon
@@ -1,5 +1,9 @@
 services:
 	-
+		class: PHPStan\Rules\PHPUnit\AssertSameBooleanExpectedRule
+		tags:
+			- phpstan.rules.rule
+	-
 		class: PHPStan\Rules\PHPUnit\AssertSameNullExpectedRule
 		tags:
 			- phpstan.rules.rule

--- a/tests/Rules/PHPUnit/AssertSameBooleanExpectedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameBooleanExpectedRuleTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\Rules\Rule;
+
+class AssertSameBooleanExpectedRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new AssertSameBooleanExpectedRule();
+	}
+
+	public function testRule()
+	{
+		$this->analyse([__DIR__ . '/data/assert-same-boolean-expected.php'], [
+			[
+				'You should use assertTrue() instead of assertSame() when expecting "true"',
+				10,
+			],
+			[
+				'You should use assertFalse() instead of assertSame() when expecting "false"',
+				11,
+			],
+			[
+				'You should use assertTrue() instead of assertSame() when expecting "true"',
+				14,
+			],
+			[
+				'You should use assertFalse() instead of assertSame() when expecting "false"',
+				17,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/PHPUnit/AssertSameDifferentTypesRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameDifferentTypesRuleTest.php
@@ -36,8 +36,20 @@ class AssertSameDifferentTypesRuleTest extends \PHPStan\Testing\RuleTestCase
 				14,
 			],
 			[
+				'Call to assertSame() with different types string and int will always result in test failure.',
+				16,
+			],
+			[
+				'Call to assertSame() with different types string and int will always result in test failure.',
+				17,
+			],
+			[
+				'Call to assertSame() with different types string and int will always result in test failure.',
+				18,
+			],
+			[
 				'Call to assertSame() with different types array<string> and array<int> will always result in test failure.',
-				35,
+				39,
 			],
 		]);
 	}

--- a/tests/Rules/PHPUnit/AssertSameNullExpectedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameNullExpectedRuleTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\Rules\Rule;
+
+class AssertSameNullExpectedRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new AssertSameNullExpectedRule();
+	}
+
+	public function testRule()
+	{
+		$this->analyse([__DIR__ . '/data/assert-same-null-expected.php'], [
+			[
+				'You should use assertNull() instead of assertSame(null, $actual).',
+				10,
+			],
+			[
+				'You should use assertNull() instead of assertSame(null, $actual).',
+				13,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/PHPUnit/AssertSameWithCountRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameWithCountRuleTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\Rules\Rule;
+
+class AssertSameWithCountRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new AssertSameWithCountRule();
+	}
+
+	public function testRule()
+	{
+		$this->analyse([__DIR__ . '/data/assert-same-count.php'], [
+			[
+				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).',
+				10,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/PHPUnit/data/Foo.php
+++ b/tests/Rules/PHPUnit/data/Foo.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Dummy;
+
+class Foo
+{
+
+	public function assertSame(): string
+	{
+		return 'Hello World!';
+	}
+
+}

--- a/tests/Rules/PHPUnit/data/assert-same-boolean-expected.php
+++ b/tests/Rules/PHPUnit/data/assert-same-boolean-expected.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase;
+
+class AssertSameBooleanExpectedTestCase extends \PHPUnit\Framework\TestCase
+{
+
+	public function testAssertSameWithBooleanAsExpected()
+	{
+		$this->assertSame(true, 'a');
+		$this->assertSame(false, 'a');
+
+		$truish = true;
+		$this->assertSame($truish, true);
+
+		$falsish = false;
+		$this->assertSame($falsish, false);
+
+		/** @var bool $a */
+		$a = null;
+		$this->assertSame($a, 'b'); // OK
+	}
+
+}

--- a/tests/Rules/PHPUnit/data/assert-same-count.php
+++ b/tests/Rules/PHPUnit/data/assert-same-count.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase;
+
+class AssertSameWithCountTestCase extends \PHPUnit\Framework\TestCase
+{
+
+	public function testAssertSameWithCount()
+	{
+		$this->assertSame(5, count([1, 2, 3]));
+	}
+
+	public function testAssertSameWithCountMethodIsOK()
+	{
+		$this->assertSame(5, $this->count()); // OK
+	}
+
+}

--- a/tests/Rules/PHPUnit/data/assert-same-null-expected.php
+++ b/tests/Rules/PHPUnit/data/assert-same-null-expected.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase;
+
+class AssertSameNullExpectedTestCase extends \PHPUnit\Framework\TestCase
+{
+
+	public function testAssertSameWithNullAsExpected()
+	{
+		$this->assertSame(null, 'a');
+
+		$a = null;
+		$this->assertSame($a, 'b');
+
+		$this->assertSame('a', 'b'); // OK
+
+		/** @var string|null $c */
+		$c = null;
+		$this->assertSame($c, 'foo'); // nullable is OK
+	}
+
+}

--- a/tests/Rules/PHPUnit/data/assert-same.php
+++ b/tests/Rules/PHPUnit/data/assert-same.php
@@ -12,6 +12,10 @@ class FooTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame(1, $this->returnsString());
 		$this->assertSame('1', self::returnsInt());
 		$this->assertSame(['a', 'b'], [1, 2]);
+
+		self::assertSame('1', 2); // test self
+		static::assertSame('1', 2); // test static
+		parent::assertSame('1', 2); // test parent
 	}
 
 	private function returnsString(): string
@@ -46,6 +50,19 @@ class FooTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame(1, self::returnsInt());
 		$this->assertSame(['a'], ['a', 1]);
 		$this->assertSame(['a', 2, 3.0], ['a', 1]);
+		self::assertSame(1, 2); // test self
+		static::assertSame(1, 2); // test static
+		parent::assertSame(1, 2); // test parent
+	}
+
+	public function testOther()
+	{
+		// assertEquals is not checked
+		$this->assertEquals('1', 1);
+
+		// only calls on \PHPUnit\Framework\TestCase are analyzed
+		$foo = new \Dummy\Foo();
+		$foo->assertSame();
 	}
 
 }


### PR DESCRIPTION
I've created several rules that suggest better assertions in PHPUnit tests.

I have a few more in the backlog, but I wanted to start small to see if we are on the same page (and the PR is already tooo long anyway).

I've tested the Rules on @driveto codebase and on PHPStan itself, but it would be great if you can try it on something bigger (such as @slevomat codebase ;-))