### PR TITLE
AssertEqualsIsDiscouraged

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It also contains this strict framework-specific rules (can be enabled separately
 * Check that you are not using `assertSame()` with `false` as expected value. `assertFalse()` should be used instead.
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
 * Check that you are not using `assertSame()` with `count($variable)` as second parameter. `assertCount($variable)` should be used instead.
+* Check that you are not using `assertEquals()` with same types (`assertSame()` should be used) or without explanatory comment above.
 
 ## How to document mock objects in phpDocs?
 

--- a/rules.neon
+++ b/rules.neon
@@ -11,3 +11,4 @@ rules:
 	- PHPStan\Rules\PHPUnit\AssertSameNullExpectedRule
 	- PHPStan\Rules\PHPUnit\AssertSameWithCountRule
 	- PHPStan\Rules\PHPUnit\MockMethodCallRule
+	- PHPStan\Rules\PHPUnit\AssertEqualsIsDiscouragedRule

--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\NodeAbstract>
+ */
+class AssertEqualsIsDiscouragedRule implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\NodeAbstract::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
+			return [];
+		}
+
+		/** @var \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\StaticCall $node */
+		$node = $node;
+
+		if (count($node->args) < 2) {
+			return [];
+		}
+		if (!$node->name instanceof Node\Identifier || strtolower($node->name->name) !== 'assertequals') {
+			return [];
+		}
+
+		$leftType = $scope->getType($node->args[0]->value);
+		$rightType = $scope->getType($node->args[1]->value);
+
+		if (
+			($leftType instanceof BooleanType && $rightType instanceof BooleanType)
+			|| ($leftType instanceof IntegerType && $rightType instanceof IntegerType)
+			|| ($leftType instanceof StringType && $rightType instanceof StringType)
+		) {
+			$typeDescription = $leftType->describe(VerbosityLevel::typeOnly());
+			if ($leftType instanceof BooleanType) {
+				$typeDescription = 'bool';
+			}
+			return [
+				sprintf(
+					'You should use assertSame instead of assertEquals, because both values are of the same type "%s"',
+					$typeDescription
+				),
+			];
+		}
+		if (
+			($leftType instanceof FloatType && $rightType instanceof FloatType)
+			&& count($node->args) < 4 // is not using delta for comparing floats
+		) {
+			return [
+				'You should use assertSame instead of assertEquals, because both values are of the same type "float" and you are not using $delta argument',
+			];
+		}
+
+		if (!$node->hasAttribute('comments')) {
+			return [
+				'You should use assertSame instead of assertEquals. Or it should have a comment above with explanation: // assertEquals because ...',
+			];
+		}
+
+		/** @var \PhpParser\Comment[] $comments */
+		$comments = $node->getAttribute('comments');
+		$comment = $comments[count($comments) - 1];
+
+		// the comment should be on the line above the assertEquals()
+		if ($comment->getLine() !== ($node->getLine() - 1)) {
+			return [
+				'You should use assertSame instead of assertEquals. Or it should have a comment above with explanation: // assertEquals because ... (The comment is not directly above the assertEquals)',
+			];
+		}
+
+		if (preg_match('~^//\s+assertEquals because(.*)~', $comment->getReformattedText()) === 0) {
+			return [
+				'You should use assertSame instead of assertEquals. Or it should have a comment above with explanation: // assertEquals because ... (There is a different comment)',
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\Rules\Rule;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<AssertEqualsIsDiscouragedRule>
+ */
+class AssertEqualsIsDiscouragedRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new AssertEqualsIsDiscouragedRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/assert-equals-is-discouraged.php'], [
+			[
+				'You should use assertSame instead of assertEquals, because both values are of the same type "string"',
+				11,
+			],
+			[
+				'You should use assertSame instead of assertEquals, because both values are of the same type "int"',
+				12,
+			],
+			[
+				'You should use assertSame instead of assertEquals, because both values are of the same type "bool"',
+				13,
+			],
+			[
+				'You should use assertSame instead of assertEquals, because both values are of the same type "float" and you are not using $delta argument',
+				16,
+			],
+			[
+				'You should use assertSame instead of assertEquals. Or it should have a comment above with explanation: // assertEquals because ... (There is a different comment)',
+				19,
+			],
+			[
+				'You should use assertSame instead of assertEquals. Or it should have a comment above with explanation: // assertEquals because ...',
+				21,
+			],
+			[
+				'You should use assertSame instead of assertEquals. Or it should have a comment above with explanation: // assertEquals because ... (There is a different comment)',
+				24,
+			],
+			[
+				'You should use assertSame instead of assertEquals. Or it should have a comment above with explanation: // assertEquals because ... (The comment is not directly above the assertEquals)',
+				28,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/PHPUnit/data/assert-equals-is-discouraged.php
+++ b/tests/Rules/PHPUnit/data/assert-equals-is-discouraged.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase;
+
+class AssertEqualsIsDiscouragedTestCase extends \PHPUnit\Framework\TestCase
+{
+
+	public function testAssertEqualsIsDiscouraged()
+	{
+		// assertSame can be used as both are of same type
+		$this->assertEquals('a', 'b');
+		$this->assertEquals(1, 2);
+		$this->assertEquals(true, false);
+
+		// comparing floats without delta
+		$this->assertEquals(1.0, 2.0);
+
+		// comparing floats with delta
+		$this->assertEquals(1.0, 2.0, '', 0.01);
+
+		$this->assertEquals(1, '1'); // assertEquals without comment on previous line
+
+		// with incorrect comment
+		$this->assertEquals(1, '1');
+
+		// assertEquals because I want it! But sadly, the comment is not just above the assert.
+
+		$this->assertEquals(1, '1');
+
+		// assertEquals because I want it!
+		$this->assertEquals(1, '1');
+	}
+
+}


### PR DESCRIPTION
This rule is even more opinionated than the previous ones.

If you don't think it should be included in PHPStan, I can change it and keep only the first part (which suggests `assertSame` in for the same types)