### PR TITLE
Expand AssertSameWithCountRule to support sizeof

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It also contains this strict framework-specific rules (can be enabled separately
 * Check that you are not using `assertSame()` with `true` as expected value. `assertTrue()` should be used instead.
 * Check that you are not using `assertSame()` with `false` as expected value. `assertFalse()` should be used instead.
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
-* Check that you are not using `assertSame()` with `count($variable)` as second parameter. `assertCount($variable)` should be used instead.
+* Check that you are not using `assertSame()` with `count($variable)`, or its alias `sizeof($variable)`, as second parameter. `assertCount($variable)` should be used instead.
 
 ## How to document mock objects in phpDocs?
 

--- a/src/Rules/PHPUnit/AssertSameWithCountRule.php
+++ b/src/Rules/PHPUnit/AssertSameWithCountRule.php
@@ -36,19 +36,14 @@ class AssertSameWithCountRule implements \PHPStan\Rules\Rule
 		if (
 			$right instanceof Node\Expr\FuncCall
 			&& $right->name instanceof Node\Name
+			&& in_array(strtolower($right->name->toString()), ['count', 'sizeof'], true)
 		) {
-			$method = strtolower($right->name->toString());
-			$message = 'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, %s($variable)).';
-
-			if ($method === 'count') {
-				return [
-					sprintf($message, 'count'),
-				];
-			} elseif ($method === 'sizeof') {
-				return [
-					sprintf($message, 'sizeof'),
-				];
-			}
+			return [
+				sprintf(
+					'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, %s($variable)).',
+					strtolower($right->name->toString())
+				),
+			];
 		}
 
 		return [];

--- a/src/Rules/PHPUnit/AssertSameWithCountRule.php
+++ b/src/Rules/PHPUnit/AssertSameWithCountRule.php
@@ -36,11 +36,19 @@ class AssertSameWithCountRule implements \PHPStan\Rules\Rule
 		if (
 			$right instanceof Node\Expr\FuncCall
 			&& $right->name instanceof Node\Name
-			&& strtolower($right->name->toString()) === 'count'
 		) {
-			return [
-				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).',
-			];
+			$method = strtolower($right->name->toString());
+			$message = 'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, %s($variable)).';
+
+			if ($method === 'count') {
+				return [
+					sprintf($message, 'count'),
+				];
+			} elseif ($method === 'sizeof') {
+				return [
+					sprintf($message, 'sizeof'),
+				];
+			}
 		}
 
 		return [];

--- a/tests/Rules/PHPUnit/AssertSameWithCountRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameWithCountRuleTest.php
@@ -19,6 +19,10 @@ class AssertSameWithCountRuleTest extends \PHPStan\Testing\RuleTestCase
 				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).',
 				10,
 			],
+			[
+				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, sizeof($variable)).',
+				20,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/data/assert-same-count.php
+++ b/tests/Rules/PHPUnit/data/assert-same-count.php
@@ -15,4 +15,13 @@ class AssertSameWithCountTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame(5, $this->count()); // OK
 	}
 
+	public function testAssertSameWithSizeOf()
+	{
+		$this->assertSame(5, sizeof([1, 2, 3]));
+	}
+
+	public function testAssertSameWithSizeOfMethodIsOK()
+	{
+		$this->assertSame(5, $this->sizeof()); // OK
+	}
 }


### PR DESCRIPTION
As suggested in #7, I've expand `AssertSameWithCountRule` to support `count`'s alias: `sizeof` :+1: 