### PR TITLE
getMockBuilder() should also work with non-existent classes

### DIFF
--- a/src/Type/PHPUnit/GetMockBuilderDynamicReturnTypeExtension.php
+++ b/src/Type/PHPUnit/GetMockBuilderDynamicReturnTypeExtension.php
@@ -4,14 +4,23 @@ namespace PHPStan\Type\PHPUnit;
 
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 
-class GetMockBuilderDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+class GetMockBuilderDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension, \PHPStan\Reflection\BrokerAwareExtension
 {
+
+	/** @var \PHPStan\Broker\Broker */
+	private $broker;
+
+	public function setBroker(Broker $broker): void
+	{
+		$this->broker = $broker;
+	}
 
 	public function getClass(): string
 	{
@@ -37,6 +46,9 @@ class GetMockBuilderDynamicReturnTypeExtension implements \PHPStan\Type\DynamicM
 
 		$class = $argType->getValue();
 
+		if (!$this->broker->hasClass($class)) {
+			return $mockBuilderType;
+		}
 		if (!$mockBuilderType instanceof TypeWithClassName) {
 			throw new \PHPStan\ShouldNotHappenException();
 		}


### PR DESCRIPTION
`TestCase::getMockBuilder()` can be used with undefined classes as well. In this case, the mock system creates dummy empty class of the given name.

This is used in Doctrine on some places, i.e. for testing event listeners that are based on naming, not interface.

Without this patch, we were getting the following errors:
```
 ------ ---------------------------------------------------------------------------- 
  Line   tests/Doctrine/Tests/DBAL/ConnectionTest.php                                
 ------ ---------------------------------------------------------------------------- 
  144    Call to method expects() on an unknown class ConnectDispatchEventListener.  
 ------ ---------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------- 
  Line   tests/Doctrine/Tests/DBAL/Functional/Schema/SchemaManagerFunctionalTestCase.php      
 ------ ------------------------------------------------------------------------------------- 
  349    Call to method expects() on an unknown class ListTableColumnsDispatchEventListener.  
  377    Call to method expects() on an unknown class ListTableIndexesDispatchEventListener.  
 ------ ------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------- 
  Line   tests/Doctrine/Tests/DBAL/Platforms/AbstractPlatformTestCase.php                     
 ------ ------------------------------------------------------------------------------------- 
  372    Call to method expects() on an unknown class GetCreateTableSqlDispatchEvenListener.  
  375    Call to method expects() on an unknown class GetCreateTableSqlDispatchEvenListener.  
  396    Call to method expects() on an unknown class GetDropTableSqlDispatchEventListener.   
  421    Call to method expects() on an unknown class GetAlterTableSqlDispatchEvenListener.   
  424    Call to method expects() on an unknown class GetAlterTableSqlDispatchEvenListener.   
  427    Call to method expects() on an unknown class GetAlterTableSqlDispatchEvenListener.   
  430    Call to method expects() on an unknown class GetAlterTableSqlDispatchEvenListener.   
  433    Call to method expects() on an unknown class GetAlterTableSqlDispatchEvenListener.   
 ------ -------------------------------------------------------------------------------------
```

No tests for Type\PHPUnit - how to add some?