### PR TITLE
Fixes failing to recognize mock methods when using getMockForTrait()

### DIFF
--- a/src/Type/PHPUnit/MockBuilderDynamicReturnTypeExtension.php
+++ b/src/Type/PHPUnit/MockBuilderDynamicReturnTypeExtension.php
@@ -49,6 +49,7 @@ class MockBuilderDynamicReturnTypeExtension implements \PHPStan\Type\DynamicMeth
 			[
 				'getMock',
 				'getMockForAbstractClass',
+				'getMockForTrait',
 			],
 			true
 		)) {

--- a/tests/Rules/PHPUnit/AssertSameMethodDifferentTypesRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameMethodDifferentTypesRuleTest.php
@@ -12,7 +12,7 @@ class AssertSameMethodDifferentTypesRuleTest extends \PHPStan\Testing\RuleTestCa
 
 	protected function getRule(): Rule
 	{
-		return new ImpossibleCheckTypeMethodCallRule(new ImpossibleCheckTypeHelper($this->getTypeSpecifier()), true);
+		return new ImpossibleCheckTypeMethodCallRule(new ImpossibleCheckTypeHelper($this->createBroker(), $this->getTypeSpecifier()), true);
 	}
 
 	/**

--- a/tests/Rules/PHPUnit/AssertSameStaticMethodDifferentTypesRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameStaticMethodDifferentTypesRuleTest.php
@@ -12,7 +12,7 @@ class AssertSameStaticMethodDifferentTypesRuleTest extends \PHPStan\Testing\Rule
 
 	protected function getRule(): Rule
 	{
-		return new ImpossibleCheckTypeStaticMethodCallRule(new ImpossibleCheckTypeHelper($this->getTypeSpecifier()), true);
+		return new ImpossibleCheckTypeStaticMethodCallRule(new ImpossibleCheckTypeHelper($this->createBroker(), $this->getTypeSpecifier()), true);
 	}
 
 	/**


### PR DESCRIPTION
This pull request fixes that PHPStan failed to recognize the mock methods when calling getMockForTrait() on the mock builder.

I also repaired the two failing tests of the current master.

#### Example:

```php
// Context: Test method in a TestCase class.

$trait = $this->getMockBuilder(MyFancyTrait::class)
              ->setMethods(['myFancyMethod'])
              ->getMockForTrait();
$trait->expects($this->once())
      ->method('myFancyMethod')
      ->with($myFancyParameter);
```

This would always trigger `Call to an undefined method PHPUnit\Framework\MockObject\MockBuilder<MyFancyTrait>::expects().`.