### PR TITLE
Enhancement: Add PHP 7.3 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 env:
   - dependencies=lowest
   - dependencies=highest

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 		"phpstan/phpstan-strict-rules": "^0.11",
 		"satooshi/php-coveralls": "^1.0",
 		"slevomat/coding-standard": "^4.5.2",
-		"phpunit/phpunit": "^7.0"
+		"phpunit/phpunit": "^7.0",
+		"squizlabs/php_codesniffer": "^3.4.0"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"


### PR DESCRIPTION
This PR

* [x] adds PHP 7.3 to the Travis CI build matrix
* [x] specifies the lowest version constraint for `squizlabs/php_codesniffer` so we can install on PHP 7.3