### PR TITLE
Fix: Use appropriate sections for Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,25 @@
 language: php
+
 php:
   - 7.1
   - 7.2
+
 env:
   - dependencies=lowest
   - dependencies=highest
-before_script:
+
+before_install:
   - composer self-update
+
+install:
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; fi;
   - if [ "$dependencies" = "highest" ]; then composer update --no-interaction; fi;
+
 script:
   - vendor/bin/phing
   - >
     wget https://github.com/maglnet/ComposerRequireChecker/releases/download/0.2.1/composer-require-checker.phar
     && php composer-require-checker.phar check composer.json
+
 after_script:
   - php vendor/bin/coveralls -v


### PR DESCRIPTION
This PR

* [x] uses appropriate sections to run things during the Travis build

💁‍♂️ Also adds a bit of vertical whitespace for enhanced legibility! For reference, see https://docs.travis-ci.com/user/job-lifecycle/#the-job-lifecycle.