### PR TITLE
Fix: No need to update composer itself twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
   - dependencies=lowest
   - dependencies=highest
 before_script:
-  - composer self-update
   - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; fi;
   - if [ "$dependencies" = "highest" ]; then composer update --no-interaction; fi;
 script:


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself twice on Travis