### PR TITLE
Fix detection of unspecific assert*() with direct Assert::assert*() calls

### DIFF
--- a/src/Rules/PHPUnit/AssertRuleHelper.php
+++ b/src/Rules/PHPUnit/AssertRuleHelper.php
@@ -9,9 +9,9 @@ use PHPStan\Type\ObjectType;
 class AssertRuleHelper
 {
 
-	public static function isMethodOrStaticCallOnTestCase(Node $node, Scope $scope): bool
+	public static function isMethodOrStaticCallOnAssert(Node $node, Scope $scope): bool
 	{
-		$testCaseType = new ObjectType('PHPUnit\Framework\TestCase');
+		$testCaseType = new ObjectType('PHPUnit\Framework\Assert');
 		if ($node instanceof Node\Expr\MethodCall) {
 			$calledOnType = $scope->getType($node->var);
 		} elseif ($node instanceof Node\Expr\StaticCall) {

--- a/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
@@ -21,7 +21,7 @@ class AssertSameBooleanExpectedRule implements \PHPStan\Rules\Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!AssertRuleHelper::isMethodOrStaticCallOnTestCase($node, $scope)) {
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
 			return [];
 		}
 

--- a/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
@@ -21,7 +21,7 @@ class AssertSameNullExpectedRule implements \PHPStan\Rules\Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!AssertRuleHelper::isMethodOrStaticCallOnTestCase($node, $scope)) {
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
 			return [];
 		}
 

--- a/src/Rules/PHPUnit/AssertSameWithCountRule.php
+++ b/src/Rules/PHPUnit/AssertSameWithCountRule.php
@@ -20,7 +20,7 @@ class AssertSameWithCountRule implements \PHPStan\Rules\Rule
 	 */
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!AssertRuleHelper::isMethodOrStaticCallOnTestCase($node, $scope)) {
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
 			return [];
 		}
 

--- a/tests/Rules/PHPUnit/AssertSameBooleanExpectedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameBooleanExpectedRuleTest.php
@@ -31,6 +31,10 @@ class AssertSameBooleanExpectedRuleTest extends \PHPStan\Testing\RuleTestCase
 				'You should use assertFalse() instead of assertSame() when expecting "false"',
 				17,
 			],
+			[
+				'You should use assertTrue() instead of assertSame() when expecting "true"',
+				26,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/AssertSameNullExpectedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameNullExpectedRuleTest.php
@@ -23,6 +23,10 @@ class AssertSameNullExpectedRuleTest extends \PHPStan\Testing\RuleTestCase
 				'You should use assertNull() instead of assertSame(null, $actual).',
 				13,
 			],
+			[
+				'You should use assertNull() instead of assertSame(null, $actual).',
+				24,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/AssertSameWithCountRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameWithCountRuleTest.php
@@ -19,6 +19,10 @@ class AssertSameWithCountRuleTest extends \PHPStan\Testing\RuleTestCase
 				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).',
 				10,
 			],
+			[
+				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).',
+				20,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/data/assert-same-boolean-expected.php
+++ b/tests/Rules/PHPUnit/data/assert-same-boolean-expected.php
@@ -21,4 +21,9 @@ class AssertSameBooleanExpectedTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame($a, 'b'); // OK
 	}
 
+	public function testAssertSameIsDetectedWithDirectAssertAccess()
+	{
+		\PHPUnit\Framework\Assert::assertSame(true, 'foo');
+	}
+
 }

--- a/tests/Rules/PHPUnit/data/assert-same-count.php
+++ b/tests/Rules/PHPUnit/data/assert-same-count.php
@@ -15,4 +15,9 @@ class AssertSameWithCountTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame(5, $this->count()); // OK
 	}
 
+	public function testAssertSameIsDetectedWithDirectAssertAccess()
+	{
+		\PHPUnit\Framework\Assert::assertSame(5, count([1, 2, 3]));
+	}
+
 }

--- a/tests/Rules/PHPUnit/data/assert-same-null-expected.php
+++ b/tests/Rules/PHPUnit/data/assert-same-null-expected.php
@@ -19,4 +19,9 @@ class AssertSameNullExpectedTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame($c, 'foo'); // nullable is OK
 	}
 
+	public function testAssertSameIsDetectedWithDirectAssertAccess()
+	{
+		\PHPUnit\Framework\Assert::assertSame(null, 'foo');
+	}
+
 }


### PR DESCRIPTION
Fixes #46.