### PR TITLE
Enhancement: Run ergebnis/composer-normalize in check target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,7 @@
 		composer,
 		lint,
 		cs,
+		composer-normalize-check,
 		tests,
 		phpstan
 	"/>
@@ -17,6 +18,31 @@
 				checkreturn="true"
 		>
 			<arg value="install"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-check">
+		<exec
+			executable="composer"
+			logoutput="true"
+			passthru="true"
+			checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
+			<arg value="--dry-run"/>
+		</exec>
+	</target>
+
+	<target name="composer-normalize-fix">
+		<exec
+			executable="composer"
+			logoutput="true"
+			passthru="true"
+			checkreturn="true"
+		>
+			<arg value="normalize"/>
+			<arg value="--ansi"/>
 		</exec>
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
 		"satooshi/php-coveralls": "^1.0",
 		"slevomat/coding-standard": "^4.7.2"
 	},
+	"config": {
+		"sort-packages": true
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "0.12-dev"

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,29 @@
 {
 	"name": "phpstan/phpstan-phpunit",
-	"description": "PHPUnit extensions and rules for PHPStan",
 	"type": "phpstan-extension",
-	"license": ["MIT"],
-	"minimum-stability": "dev",
-	"prefer-stable": true,
+	"description": "PHPUnit extensions and rules for PHPStan",
+	"license": [
+		"MIT"
+	],
+	"require": {
+		"php": "~7.1",
+		"nikic/php-parser": "^4.0",
+		"phpstan/phpstan": "^0.12"
+	},
+	"conflict": {
+		"phpunit/phpunit": "<7.0"
+	},
+	"require-dev": {
+		"consistence/coding-standard": "^3.5",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+		"ergebnis/composer-normalize": "^2.0.2",
+		"jakub-onderka/php-parallel-lint": "^1.0",
+		"phing/phing": "^2.16.0",
+		"phpstan/phpstan-strict-rules": "^0.12",
+		"phpunit/phpunit": "^7.0",
+		"satooshi/php-coveralls": "^1.0",
+		"slevomat/coding-standard": "^4.7.2"
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "0.12-dev"
@@ -16,31 +35,16 @@
 			]
 		}
 	},
-	"require": {
-		"php": "~7.1",
-		"phpstan/phpstan": "^0.12",
-		"nikic/php-parser": "^4.0"
-	},
-	"require-dev": {
-		"consistence/coding-standard": "^3.5",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-		"jakub-onderka/php-parallel-lint": "^1.0",
-		"phing/phing": "^2.16.0",
-		"phpstan/phpstan-strict-rules": "^0.12",
-		"satooshi/php-coveralls": "^1.0",
-		"slevomat/coding-standard": "^4.7.2",
-		"phpunit/phpunit": "^7.0",
-		"ergebnis/composer-normalize": "^2.0.2"
-	},
-	"conflict": {
-		"phpunit/phpunit": "<7.0"
-	},
 	"autoload": {
 		"psr-4": {
 			"PHPStan\\": "src/"
 		}
 	},
 	"autoload-dev": {
-		"classmap": ["tests/"]
-	}
+		"classmap": [
+			"tests/"
+		]
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
 		"phpstan/phpstan-strict-rules": "^0.12",
 		"satooshi/php-coveralls": "^1.0",
 		"slevomat/coding-standard": "^4.7.2",
-		"phpunit/phpunit": "^7.0"
+		"phpunit/phpunit": "^7.0",
+		"ergebnis/composer-normalize": "^2.0.2"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"


### PR DESCRIPTION
This PR

* [x] runs `ergebnis/composer-normalize` with the `--dry-run` option in the `check` target
* [x] runs `composer normalize`
* [x] keeps packages sorted in `composer.json`