### PR TITLE
Allow extending only from specified classes in unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It also contains this strict framework-specific rules (can be enabled separately
 * Check that you are not using `assertSame()` with `false` as expected value. `assertFalse()` should be used instead.
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
 * Check that you are not using `assertSame()` with `count($variable)` as second parameter. `assertCount($variable)` should be used instead.
+* Check that you are extending only from `\PHPUnit\Framework\TestCase` in unit tests (test cases in a namespace containing the word `Unit`).
 
 ## How to document mock objects in phpDocs?
 

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
 	],
 	"require": {
 		"php": "~7.1",
+		"nette/utils": "^3.1",
 		"phpstan/phpstan": "^0.12.4"
 	},
 	"conflict": {

--- a/rules.neon
+++ b/rules.neon
@@ -2,3 +2,4 @@ rules:
 	- PHPStan\Rules\PHPUnit\AssertSameBooleanExpectedRule
 	- PHPStan\Rules\PHPUnit\AssertSameNullExpectedRule
 	- PHPStan\Rules\PHPUnit\AssertSameWithCountRule
+	- PHPStan\Rules\PHPUnit\UnitExtendsFromTestCaseRule

--- a/src/Rules/PHPUnit/UnitExtendsFromTestCaseRule.php
+++ b/src/Rules/PHPUnit/UnitExtendsFromTestCaseRule.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\Class_>
+ */
+class UnitExtendsFromTestCaseRule implements \PHPStan\Rules\Rule
+{
+
+	private const ALLOWED_EXTENDED_CLASSES = [
+		\PHPUnit\Framework\TestCase::class,
+		\PHPStan\Testing\RuleTestCase::class,
+	];
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\Class_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		/** @var Node\Stmt\Class_ $node */
+
+		$namespace = $scope->getNamespace();
+		if ($namespace === null
+			|| !Strings::contains($namespace, 'Unit')
+			|| !Strings::endsWith((string) $node->name, 'Test')
+		) { // only unit tests are considered
+			return [];
+		}
+
+		$extendedClass = $node->extends;
+		if ($extendedClass === null || !in_array($extendedClass->toString(), self::ALLOWED_EXTENDED_CLASSES, true)) {
+			return [
+				sprintf(
+					'You should only extend from one of the following classes in unit tests: "%s".',
+					implode(', ', self::ALLOWED_EXTENDED_CLASSES)
+				),
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/tests/Rules/PHPUnit/UnitExtendsFromTestCaseRuleTest.php
+++ b/tests/Rules/PHPUnit/UnitExtendsFromTestCaseRuleTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<UnitExtendsFromTestCaseRule>
+ */
+class UnitExtendsFromTestCaseRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new UnitExtendsFromTestCaseRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/unit-extends/unit-extends-exception.php'], []);
+		$this->analyse([__DIR__ . '/data/unit-extends/unit-extends-no-namespace.php'], []);
+		$this->analyse([__DIR__ . '/data/unit-extends/unit-extends-functional-test.php'], []);
+		$this->analyse([__DIR__ . '/data/unit-extends/unit-extends-ok-test.php'], []);
+		$this->analyse([__DIR__ . '/data/unit-extends/unit-extends-not-extending-test.php'], [
+			[
+				'You should only extend from one of the following classes in unit tests: "PHPUnit\Framework\TestCase, PHPStan\Testing\RuleTestCase".',
+				05,
+			],
+		]);
+		$this->analyse([__DIR__ . '/data/unit-extends/unit-extends-invalid-test.php'], [
+			[
+				'You should only extend from one of the following classes in unit tests: "PHPUnit\Framework\TestCase, PHPStan\Testing\RuleTestCase".',
+				05,
+			],
+		]);
+	}
+
+}

--- a/tests/Rules/PHPUnit/data/unit-extends/FunctionalDummyTest.php
+++ b/tests/Rules/PHPUnit/data/unit-extends/FunctionalDummyTest.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Dummy;
+
+abstract class FunctionalDummyTest extends \PHPUnit\Framework\TestCase
+{
+
+}

--- a/tests/Rules/PHPUnit/data/unit-extends/unit-extends-exception.php
+++ b/tests/Rules/PHPUnit/data/unit-extends/unit-extends-exception.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase\Unit;
+
+class UnitExtendsException extends \Exception
+{
+}

--- a/tests/Rules/PHPUnit/data/unit-extends/unit-extends-functional-test.php
+++ b/tests/Rules/PHPUnit/data/unit-extends/unit-extends-functional-test.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase\Functional;
+
+class UnitExtendsFunctionalTest extends \Dummy\FunctionalDummyTest
+{
+	public function testSomething(): void
+	{
+		$this->assertTrue(true);
+	}
+}

--- a/tests/Rules/PHPUnit/data/unit-extends/unit-extends-invalid-test.php
+++ b/tests/Rules/PHPUnit/data/unit-extends/unit-extends-invalid-test.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase\Unit;
+
+class UnitExtendsInvalidTest extends \Dummy\FunctionalDummyTest
+{
+	public function testSomeThing(): void
+	{
+		$this->assertTrue(true);
+	}
+}

--- a/tests/Rules/PHPUnit/data/unit-extends/unit-extends-no-namespace.php
+++ b/tests/Rules/PHPUnit/data/unit-extends/unit-extends-no-namespace.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types = 1);
+
+class UnitExtendsNoNamespace extends \Exception
+{
+}

--- a/tests/Rules/PHPUnit/data/unit-extends/unit-extends-not-extending-test.php
+++ b/tests/Rules/PHPUnit/data/unit-extends/unit-extends-not-extending-test.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase\Unit;
+
+class UnitExtendsNotExtendingTest
+{
+	public function testSomeThing(): void
+	{
+		// pass
+	}
+}

--- a/tests/Rules/PHPUnit/data/unit-extends/unit-extends-ok-test.php
+++ b/tests/Rules/PHPUnit/data/unit-extends/unit-extends-ok-test.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase\Unit;
+
+class UnitExtendsUnitTest extends \PHPUnit\Framework\TestCase
+{
+	public function testSomeThing(): void
+	{
+		$this->assertTrue(true);
+	}
+}


### PR DESCRIPTION
Hi, this experimental PR adds a new strict rule to allow extending only from PHPUnit's TestCase in unit tests. E.g. `class MyTest extends AbstractKernelTestCase` will fail.

**Issue to be fixed:** It should fix the problem when developers use DI containers in unit tests and overuse inheritance by using custom abstract classes.

Please, consider this as a work-in-progress. I will be very glad for any comment or suggestion (it is my first real open source PR). Thanks :)