### PR TITLE
Use the parent Assert class for earlyTerminatingMethodCalls

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -2,7 +2,7 @@ parameters:
 	additionalConstructors:
 		- PHPUnit\Framework\TestCase::setUp
 	earlyTerminatingMethodCalls:
-		PHPUnit\Framework\TestCase:
+		PHPUnit\Framework\Assert:
 			- fail
 			- markTestIncomplete
 			- markTestSkipped


### PR DESCRIPTION
Just getting started with phpstan so forgive me if this won't work as I expect.

I have several custom objects that have phpunit assertions. I call `PHPUnit\Framework\Assert::fail()` from them and was getting false positive return missing errors. Since `PHPUnit\Framework\TestCase` extends from `PHPUnit\Framework\Assert`, I believe this won't break anything.