### PR TITLE
Avoid addMethod issue with stdClass

### DIFF
--- a/src/Rules/PHPUnit/MockMethodCallRule.php
+++ b/src/Rules/PHPUnit/MockMethodCallRule.php
@@ -52,6 +52,12 @@ class MockMethodCallRule implements \PHPStan\Rules\Rule
 				return $class !== MockObject::class;
 			});
 
+			// `MockBuilder::setMethods` and `MockBuilder::addMethods` are not supported by this rule
+			// so since a lot of the usage are with `stdClass`, we silent the error
+			if (\implode('&', $mockClass) === 'stdClass') {
+				return [];
+			}
+
 			return [
 				sprintf(
 					'Trying to mock an undefined method %s() on class %s.',

--- a/tests/Rules/PHPUnit/MockMethodCallRuleTest.php
+++ b/tests/Rules/PHPUnit/MockMethodCallRuleTest.php
@@ -26,6 +26,10 @@ class MockMethodCallRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Trying to mock an undefined method doBadThing() on class MockMethodCall\Bar.',
 				20,
 			],
+			[
+				'Trying to mock an undefined method doBadThing() on class MockMethodCall\Bar.',
+				31,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/data/mock-method-call.php
+++ b/tests/Rules/PHPUnit/data/mock-method-call.php
@@ -31,9 +31,9 @@ class Foo extends \PHPUnit\Framework\TestCase
 		$this->getMockBuilder(Bar::class)->getMock()->method('doBadThing');
 	}
 
-	public function testWhenAddingMethod()
+	public function testWhenAddingMethodToStdClass()
 	{
-		$this->getMockBuilder(Bar::class)->setMethods(['doBadThing'])->getMock()->method('doBadThing');
+		$this->getMockBuilder(\stdClass::class)->setMethods(['doBadThing'])->getMock()->method('doBadThing');
 	}
 
 }

--- a/tests/Rules/PHPUnit/data/mock-method-call.php
+++ b/tests/Rules/PHPUnit/data/mock-method-call.php
@@ -26,6 +26,16 @@ class Foo extends \PHPUnit\Framework\TestCase
 		$bar->method('doBadThing');
 	}
 
+	public function testWithMockBuilder()
+	{
+		$this->getMockBuilder(Bar::class)->getMock()->method('doBadThing');
+	}
+
+	public function testWhenAddingMethod()
+	{
+		$this->getMockBuilder(Bar::class)->setMethods(['doBadThing'])->getMock()->method('doBadThing');
+	}
+
 }
 
 class Bar {


### PR DESCRIPTION
Since the tests are written with phpunit@7, I used `setMethods()`.
But the issue also exists with `addMethods()`