### PR TITLE
Add support for assertObjectHasAttribute

### DIFF
--- a/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
+++ b/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
@@ -255,6 +255,9 @@ class AssertTypeSpecifyingExtensionHelper
 				'ArrayHasKey' => function (Scope $scope, Arg $key, Arg $array): FuncCall {
 					return new \PhpParser\Node\Expr\FuncCall(new Name('array_key_exists'), [$key, $array]);
 				},
+				'ObjectHasAttribute' => function (Scope $scope, Arg $property, Arg $object): FuncCall {
+					return new \PhpParser\Node\Expr\FuncCall(new Name('property_exists'), [$object, $property]);
+				},
 			];
 		}
 

--- a/tests/Type/PHPUnit/data/assert-function.php
+++ b/tests/Type/PHPUnit/data/assert-function.php
@@ -4,8 +4,8 @@ namespace AssertFunction;
 
 use function PHPStan\Testing\assertType;
 use function PHPUnit\Framework\assertArrayHasKey;
-use function PHPUnit\Framework\assertArrayNotHasKey;
 use function PHPUnit\Framework\assertInstanceOf;
+use function PHPUnit\Framework\assertObjectHasAttribute;
 
 class Foo
 {
@@ -28,6 +28,12 @@ class Foo
 	{
 		assertArrayHasKey('key', $a);
 		assertType("array&hasOffset('key')", $a);
+	}
+
+	public function objectHasAttribute(object $a): void
+	{
+		assertObjectHasAttribute('property', $a);
+		assertType("object&hasProperty(property)", $a);
 	}
 
 }


### PR DESCRIPTION
This adds support for `assertObjectHasAttribute()`, so that PHPStan will not complain when writing tests like:

```php
assertObjectHasAttribute('foo', $someObject);
assertSame(123, $someObject->foo);
```