### PR TITLE
Add type specifying support for classes extending Assert

### DIFF
--- a/src/Type/PHPUnit/Assert/AssertMethodTypeSpecifyingExtension.php
+++ b/src/Type/PHPUnit/Assert/AssertMethodTypeSpecifyingExtension.php
@@ -24,7 +24,7 @@ class AssertMethodTypeSpecifyingExtension implements MethodTypeSpecifyingExtensi
 
 	public function getClass(): string
 	{
-		return 'PHPUnit\Framework\TestCase';
+		return 'PHPUnit\Framework\Assert';
 	}
 
 	public function isMethodSupported(

--- a/tests/Type/PHPUnit/AssertMethodTypeSpecifyingExtensionTest.php
+++ b/tests/Type/PHPUnit/AssertMethodTypeSpecifyingExtensionTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\PHPUnit;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class AssertMethodTypeSpecifyingExtensionTest extends TypeInferenceTestCase
+{
+
+	/** @return mixed[] */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-method.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param string $assertType
+	 * @param string $file
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [__DIR__ . '/../../../extension.neon'];
+	}
+
+}

--- a/tests/Type/PHPUnit/data/assert-method.php
+++ b/tests/Type/PHPUnit/data/assert-method.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AssertMethod;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function inheritedAssertMethodsNarrowType(?string $s): void
+	{
+		$customAsserter = new class () extends \PHPUnit\Framework\Assert {};
+		$customAsserter->assertNotNull($s);
+		assertType('string', $s);
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan-phpunit/issues/103

The actual `assert*` methods are implemented in `PHPUnit\Framework\Assert` not in `PHPUnit\Framework\TestCase`