### PR TITLE
Validate coverage tags point to real classes

### DIFF
--- a/src/Rules/PHPUnit/CoversShouldExistRule.php
+++ b/src/Rules/PHPUnit/CoversShouldExistRule.php
@@ -1,0 +1,185 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+use function array_merge;
+use function explode;
+use function sprintf;
+use function strpos;
+
+/**
+ * @implements Rule<Node>
+ */
+class CoversShouldExistRule implements Rule
+{
+
+	/**
+	 * Document lexer.
+	 *
+	 * @var Lexer
+	 */
+	private $phpDocLexer;
+
+	/**
+	 * Document parser.
+	 *
+	 * @var PhpDocParser
+	 */
+	private $phpDocParser;
+
+	/**
+	 * Reflection provider.
+	 *
+	 * @var ReflectionProvider
+	 */
+	private $reflectionProvider;
+
+	public function __construct(
+		Lexer $phpDocLexer,
+		PhpDocParser $phpDocParser,
+		ReflectionProvider $reflectionProvider
+	)
+	{
+		$this->phpDocParser = $phpDocParser;
+		$this->phpDocLexer = $phpDocLexer;
+		$this->reflectionProvider = $reflectionProvider;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (
+			!$node instanceof Node\Stmt\ClassLike
+			&& !$node instanceof Node\Stmt\ClassMethod
+		) {
+			// @todo should we make sure covers tags aren't in weird places?
+			return [];
+		}
+
+		$docComment = $node->getDocComment();
+		if ($docComment === null) {
+			return [];
+		}
+		$phpDocNode = $this->getDocNode($docComment);
+
+		$errors = [];
+		foreach ($phpDocNode->getTags() as $phpDocTag) {
+			switch ($phpDocTag->name) {
+				case '@covers':
+					$errors = array_merge(
+						$errors,
+						$this->processCovers($node, $phpDocTag)
+					);
+					break;
+				case '@coversDefaultClass':
+					$errors = array_merge(
+						$errors,
+						$this->processCoversDefault($node, $phpDocTag)
+					);
+					break;
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * @return RuleError[] errors
+	 * @throws ShouldNotHappenException
+	 */
+	private function processCoversDefault(
+		Node $node,
+		PhpDocTagNode $phpDocTag
+	): array
+	{
+		$errors = [];
+		if ($node instanceof Node\Stmt\ClassMethod) {
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'@coversDefaultClass found on class method %s.',
+				$node->name
+			))->build();
+		} else {
+			$className = (string) $phpDocTag->value;
+			if (!$this->reflectionProvider->hasClass($className)) {
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'@coversDefaultClass does not provide a known class %s.',
+					$className
+				))->build();
+			}
+		}
+		return $errors;
+	}
+
+	/**
+	 * @return RuleError[] errors
+	 * @throws ShouldNotHappenException
+	 */
+	private function processCovers(Node $node, PhpDocTagNode $phpDocTag): array
+	{
+		$errors = [];
+		$covers = (string) $phpDocTag->value;
+
+		if (strpos($covers, '::') === false) {
+			[$className, $method] = explode('::', $covers);
+		} else {
+			$className = $covers;
+		}
+		if ($className === '') {
+			if ($node instanceof Node\Stmt\ClassMethod) {
+				$parent = $node->getAttribute('parent');
+				if ($parent instanceof Node\Stmt\Class_) {
+					$docComment = $parent->getDocComment();
+					if ($docComment !== null) {
+						$phpDocNode = $this->getDocNode($docComment);
+						foreach ($phpDocNode->getTags() as $phpDocTag2) {
+							if ($phpDocTag2->name === '@coversDefaultClass') {
+								$className = (string) $phpDocTag2->value;
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+		if ($this->reflectionProvider->hasClass($className)) {
+			$class = $this->reflectionProvider->getClass($className);
+			if (isset($method) && $method !== '' && !$class->hasMethod($method)) {
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'@covers value %s references an unknown method.',
+					$covers
+				))->build();
+			}
+		} else {
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'@covers value %s references an unknown class.',
+				$covers
+			))->build();
+		}
+		return $errors;
+	}
+
+	private function getDocNode(Doc $docComment): PhpDocNode
+	{
+		$phpDocString = $docComment->getText();
+		$tokens = new TokenIterator($this->phpDocLexer->tokenize($phpDocString));
+		return $this->phpDocParser->parse($tokens);
+	}
+
+}

--- a/tests/Rules/PHPUnit/CoversShouldExistRuleTest.php
+++ b/tests/Rules/PHPUnit/CoversShouldExistRuleTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CoversShouldExistRule>
+ * @covers \PHPStan\Rules\PHPUnit\CoversShouldExistRule::processCoversDefault
+ */
+class CoversShouldExistRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		$broker = $this->createReflectionProvider();
+		return new CoversShouldExistRule(
+			self::getContainer()->getByType(Lexer::class),
+			self::getContainer()->getByType(PhpDocParser::class),
+			$broker
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/coverage.php'], [
+			[
+				'@coversDefaultClass does not provide a known class \Not\A\Class.',
+				8,
+			],
+			[
+				'@covers value ::ignoreThis references an unknown class.',
+				14,
+			],
+			[
+				'@covers value \PHPUnit\Framework\TestCase::assertNotReal references an unknown method.',
+				28,
+			],
+			[
+				'@covers value \Not\A\Class::foo references an unknown class.',
+				35,
+			],
+			[
+				'@coversDefaultClass found on class method testBadCoversDefault.',
+				50,
+			],
+			[
+				'@covers value ::assertNotReal references an unknown method.',
+				62,
+			],
+		]);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../extension.neon',
+		];
+	}
+
+}

--- a/tests/Rules/PHPUnit/data/coverage.php
+++ b/tests/Rules/PHPUnit/data/coverage.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace ExampleTestCase;
+
+/**
+ * @coversDefaultClass \Not\A\Class
+ */
+class CoversShouldExistTestCase extends \PHPUnit\Framework\TestCase
+{
+
+	/**
+	 * @covers ::ignoreThis
+	 */
+	public function testFunctionCoversBroken()
+	{
+	}
+
+	/**
+	 * @covers \PHPUnit\Framework\TestCase::assertEquals
+	 */
+	public function testFunctionCoversGoodFQDN()
+	{
+	}
+
+	/**
+	 * @covers \PHPUnit\Framework\TestCase::assertNotReal
+	 */
+	public function testFunctionCoversBadFQDN()
+	{
+	}
+
+	/**
+	 * @covers \Not\A\Class::foo
+	 */
+	public function testFunctionCoversBadFQDN2()
+	{
+	}
+
+}
+
+/**
+ * @coversDefaultClass \PHPUnit\Framework\TestCase
+ */
+class CoversShouldExistTestCase2 extends \PHPUnit\Framework\TestCase
+{
+
+	/**
+	 * @coversDefaultClass \ExampleTestCase\CoversShouldExistTestCase
+	 */
+	public function testBadCoversDefault() {}
+
+	/**
+	 * @covers ::assertEquals
+	 */
+	public function testFunctionCoversRealFunction()
+	{
+	}
+
+	/**
+	 * @covers ::assertNotReal
+	 */
+	public function testFunctionCoversBroken()
+	{
+	}
+
+}
+
+/**
+ * @covers \PHPUnit\Framework\TestCase
+ */
+class CoversShouldExistTestCase3 extends \PHPUnit\Framework\TestCase
+{
+
+	/**
+	 * @covers \PHPUnit\Framework\TestCase
+	 */
+	public function testBadCoversDefault() {}
+
+}


### PR DESCRIPTION
Its easy to make typos or miss updating a covers tag during a refactor and this helps catch it earlier.