### PR TITLE
Report only direct `false`|`true`|`null` for `assertFalse()`|`assertTrue()`|`assertNull()`

### DIFF
--- a/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
@@ -3,12 +3,12 @@
 namespace PHPStan\Rules\PHPUnit;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\NodeAbstract;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Type\Constant\ConstantBooleanType;
 use function count;
 use function strtolower;
 
@@ -39,20 +39,24 @@ class AssertSameBooleanExpectedRule implements Rule
 			return [];
 		}
 
-		$leftType = $scope->getType($node->getArgs()[0]->value);
-		if (!$leftType instanceof ConstantBooleanType) {
+		$expectedArgumentValue = $node->getArgs()[0]->value;
+		if (!($expectedArgumentValue instanceof ConstFetch)) {
 			return [];
 		}
 
-		if ($leftType->getValue()) {
+		if ($expectedArgumentValue->name->toLowerString() === 'true') {
 			return [
 				'You should use assertTrue() instead of assertSame() when expecting "true"',
 			];
 		}
 
-		return [
-			'You should use assertFalse() instead of assertSame() when expecting "false"',
-		];
+		if ($expectedArgumentValue->name->toLowerString() === 'false') {
+			return [
+				'You should use assertFalse() instead of assertSame() when expecting "false"',
+			];
+		}
+
+		return [];
 	}
 
 }

--- a/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
@@ -3,12 +3,12 @@
 namespace PHPStan\Rules\PHPUnit;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\NodeAbstract;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Type\NullType;
 use function count;
 use function strtolower;
 
@@ -39,9 +39,12 @@ class AssertSameNullExpectedRule implements Rule
 			return [];
 		}
 
-		$leftType = $scope->getType($node->getArgs()[0]->value);
+		$expectedArgumentValue = $node->getArgs()[0]->value;
+		if (!($expectedArgumentValue instanceof ConstFetch)) {
+			return [];
+		}
 
-		if ($leftType instanceof NullType) {
+		if ($expectedArgumentValue->name->toLowerString() === 'null') {
 			return [
 				'You should use assertNull() instead of assertSame(null, $actual).',
 			];

--- a/tests/Rules/PHPUnit/AssertSameBooleanExpectedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameBooleanExpectedRuleTest.php
@@ -39,6 +39,30 @@ class AssertSameBooleanExpectedRuleTest extends RuleTestCase
 				'You should use assertTrue() instead of assertSame() when expecting "true"',
 				26,
 			],
+			[
+				'You should use assertTrue() instead of assertSame() when expecting "true"',
+				31,
+			],
+			[
+				'You should use assertFalse() instead of assertSame() when expecting "false"',
+				32,
+			],
+			[
+				'You should use assertTrue() instead of assertSame() when expecting "true"',
+				40,
+			],
+			[
+				'You should use assertFalse() instead of assertSame() when expecting "false"',
+				41,
+			],
+			[
+				'You should use assertTrue() instead of assertSame() when expecting "true"',
+				67,
+			],
+			[
+				'You should use assertFalse() instead of assertSame() when expecting "false"',
+				68,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/AssertSameBooleanExpectedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameBooleanExpectedRuleTest.php
@@ -29,39 +29,15 @@ class AssertSameBooleanExpectedRuleTest extends RuleTestCase
 			],
 			[
 				'You should use assertTrue() instead of assertSame() when expecting "true"',
-				14,
-			],
-			[
-				'You should use assertFalse() instead of assertSame() when expecting "false"',
-				17,
-			],
-			[
-				'You should use assertTrue() instead of assertSame() when expecting "true"',
 				26,
 			],
 			[
 				'You should use assertTrue() instead of assertSame() when expecting "true"',
-				31,
+				74,
 			],
 			[
 				'You should use assertFalse() instead of assertSame() when expecting "false"',
-				32,
-			],
-			[
-				'You should use assertTrue() instead of assertSame() when expecting "true"',
-				40,
-			],
-			[
-				'You should use assertFalse() instead of assertSame() when expecting "false"',
-				41,
-			],
-			[
-				'You should use assertTrue() instead of assertSame() when expecting "true"',
-				67,
-			],
-			[
-				'You should use assertFalse() instead of assertSame() when expecting "false"',
-				68,
+				75,
 			],
 		]);
 	}

--- a/tests/Rules/PHPUnit/AssertSameNullExpectedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameNullExpectedRuleTest.php
@@ -31,6 +31,18 @@ class AssertSameNullExpectedRuleTest extends RuleTestCase
 				'You should use assertNull() instead of assertSame(null, $actual).',
 				24,
 			],
+			[
+				'You should use assertNull() instead of assertSame(null, $actual).',
+				29,
+			],
+			[
+				'You should use assertNull() instead of assertSame(null, $actual).',
+				36,
+			],
+			[
+				'You should use assertNull() instead of assertSame(null, $actual).',
+				54,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/AssertSameNullExpectedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameNullExpectedRuleTest.php
@@ -25,23 +25,11 @@ class AssertSameNullExpectedRuleTest extends RuleTestCase
 			],
 			[
 				'You should use assertNull() instead of assertSame(null, $actual).',
-				13,
-			],
-			[
-				'You should use assertNull() instead of assertSame(null, $actual).',
 				24,
 			],
 			[
 				'You should use assertNull() instead of assertSame(null, $actual).',
-				29,
-			],
-			[
-				'You should use assertNull() instead of assertSame(null, $actual).',
-				36,
-			],
-			[
-				'You should use assertNull() instead of assertSame(null, $actual).',
-				54,
+				60,
 			],
 		]);
 	}

--- a/tests/Rules/PHPUnit/data/assert-same-boolean-expected.php
+++ b/tests/Rules/PHPUnit/data/assert-same-boolean-expected.php
@@ -11,10 +11,10 @@ class AssertSameBooleanExpectedTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame(false, 'a');
 
 		$truish = true;
-		$this->assertSame($truish, true);
+		$this->assertSame($truish, true); // using variable is OK
 
 		$falsish = false;
-		$this->assertSame($falsish, false);
+		$this->assertSame($falsish, false); // using variable is OK
 
 		/** @var bool $a */
 		$a = null;
@@ -67,6 +67,12 @@ class AssertSameBooleanExpectedTestCase extends \PHPUnit\Framework\TestCase
 		\PHPUnit\Framework\Assert::assertSame($this->returnTrue(), 'foo');
 		\PHPUnit\Framework\Assert::assertSame($this->returnFalse(), 'foo');
 		\PHPUnit\Framework\Assert::assertSame($this->returnBool(), 'foo');
+	}
+
+	public function testNonLowercase(): void
+	{
+		\PHPUnit\Framework\Assert::assertSame(True, 'foo');
+		\PHPUnit\Framework\Assert::assertSame(False, 'foo');
 	}
 
 }

--- a/tests/Rules/PHPUnit/data/assert-same-boolean-expected.php
+++ b/tests/Rules/PHPUnit/data/assert-same-boolean-expected.php
@@ -26,4 +26,50 @@ class AssertSameBooleanExpectedTestCase extends \PHPUnit\Framework\TestCase
 		\PHPUnit\Framework\Assert::assertSame(true, 'foo');
 	}
 
+	public function testConstants(): void
+	{
+		\PHPUnit\Framework\Assert::assertSame(PHPSTAN_PHPUNIT_TRUE, 'foo');
+		\PHPUnit\Framework\Assert::assertSame(PHPSTAN_PHPUNIT_FALSE, 'foo');
+	}
+
+	private const TRUE = true;
+	private const FALSE = false;
+
+	public function testClassConstants(): void
+	{
+		\PHPUnit\Framework\Assert::assertSame(self::TRUE, 'foo');
+		\PHPUnit\Framework\Assert::assertSame(self::FALSE, 'foo');
+	}
+
+	public function returnBool(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return true
+	 */
+	public function returnTrue(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * @return false
+	 */
+	public function returnFalse(): bool
+	{
+		return false;
+	}
+
+	public function testMethodCalls(): void
+	{
+		\PHPUnit\Framework\Assert::assertSame($this->returnTrue(), 'foo');
+		\PHPUnit\Framework\Assert::assertSame($this->returnFalse(), 'foo');
+		\PHPUnit\Framework\Assert::assertSame($this->returnBool(), 'foo');
+	}
+
 }
+
+const PHPSTAN_PHPUNIT_TRUE = true;
+const PHPSTAN_PHPUNIT_FALSE = false;

--- a/tests/Rules/PHPUnit/data/assert-same-null-expected.php
+++ b/tests/Rules/PHPUnit/data/assert-same-null-expected.php
@@ -24,4 +24,37 @@ class AssertSameNullExpectedTestCase extends \PHPUnit\Framework\TestCase
 		\PHPUnit\Framework\Assert::assertSame(null, 'foo');
 	}
 
+	public function testConstant(): void
+	{
+		\PHPUnit\Framework\Assert::assertSame(PHPSTAN_PHPUNIT_NULL, 'foo');
+	}
+
+	private const NULL = null;
+
+	public function testClassConstant(): void
+	{
+		\PHPUnit\Framework\Assert::assertSame(self::NULL, 'foo');
+	}
+
+	public function returnNullable(): ?string
+	{
+
+	}
+
+	/**
+	 * @return null
+	 */
+	public function returnNull()
+	{
+		return null;
+	}
+
+	public function testMethodCalls(): void
+	{
+		\PHPUnit\Framework\Assert::assertSame($this->returnNull(), 'foo');
+		\PHPUnit\Framework\Assert::assertSame($this->returnNullable(), 'foo');
+	}
+
 }
+
+const PHPSTAN_PHPUNIT_NULL = null;

--- a/tests/Rules/PHPUnit/data/assert-same-null-expected.php
+++ b/tests/Rules/PHPUnit/data/assert-same-null-expected.php
@@ -10,7 +10,7 @@ class AssertSameNullExpectedTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame(null, 'a');
 
 		$a = null;
-		$this->assertSame($a, 'b');
+		$this->assertSame($a, 'b'); // using variable is OK
 
 		$this->assertSame('a', 'b'); // OK
 
@@ -53,6 +53,11 @@ class AssertSameNullExpectedTestCase extends \PHPUnit\Framework\TestCase
 	{
 		\PHPUnit\Framework\Assert::assertSame($this->returnNull(), 'foo');
 		\PHPUnit\Framework\Assert::assertSame($this->returnNullable(), 'foo');
+	}
+
+	public function testNonLowercase(): void
+	{
+		\PHPUnit\Framework\Assert::assertSame(Null, 'foo');
 	}
 
 }


### PR DESCRIPTION
In your test, if I write code like this:

```php
$name = 'Ikea';
$popular = true;

$brand = $brandService->createBrand(
	$name,
	$popular
	// ...
);

Assert::assertSame($name, $brand->getName());
Assert::assertSame($popular, $brand->getPopular());
```

I get:

```
You should use assertTrue() instead of assertSame() when expecting "true"
```

But that would mean that I cannot use the variable, which I think would lead to worse code, because:

1. readability - this is a very simplified example, but using the same variable is beneficial to finding where the value came from
2. as seen in added tests - it is not only about variables, but also constants etc. - i think this is even more important then to see where the value really came from
3. code written using variables like this is easily converted to use dataProviders

The same reasoning can be applied to `assertNull()` rule.