### PR TITLE
Add rule to check @dataProvider

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -55,6 +55,8 @@ services:
 		class: PHPStan\Rules\PHPUnit\CoversHelper
 	-
 		class: PHPStan\Rules\PHPUnit\AnnotationHelper
+	-
+		class: PHPStan\Rules\PHPUnit\DataProviderHelper
 
 conditionalTags:
 	PHPStan\PhpDoc\PHPUnit\MockObjectTypeNodeResolverExtension:

--- a/rules.neon
+++ b/rules.neon
@@ -8,6 +8,7 @@ rules:
 services:
 	- class: PHPStan\Rules\PHPUnit\ClassCoversExistsRule
 	- class: PHPStan\Rules\PHPUnit\ClassMethodCoversExistsRule
+	- class: PHPStan\Rules\PHPUnit\DataProviderDeclarationRule
 	- class: PHPStan\Rules\PHPUnit\NoMissingSpaceInClassAnnotationRule
 	- class: PHPStan\Rules\PHPUnit\NoMissingSpaceInMethodAnnotationRule
 
@@ -15,6 +16,8 @@ conditionalTags:
 	PHPStan\Rules\PHPUnit\ClassCoversExistsRule:
 		phpstan.rules.rule: %featureToggles.bleedingEdge%
 	PHPStan\Rules\PHPUnit\ClassMethodCoversExistsRule:
+		phpstan.rules.rule: %featureToggles.bleedingEdge%
+	PHPStan\Rules\PHPUnit\DataProviderDeclarationRule:
 		phpstan.rules.rule: %featureToggles.bleedingEdge%
 	PHPStan\Rules\PHPUnit\NoMissingSpaceInClassAnnotationRule:
 		phpstan.rules.rule: %featureToggles.bleedingEdge%

--- a/rules.neon
+++ b/rules.neon
@@ -8,7 +8,10 @@ rules:
 services:
 	- class: PHPStan\Rules\PHPUnit\ClassCoversExistsRule
 	- class: PHPStan\Rules\PHPUnit\ClassMethodCoversExistsRule
-	- class: PHPStan\Rules\PHPUnit\DataProviderDeclarationRule
+	-
+		class: PHPStan\Rules\PHPUnit\DataProviderDeclarationRule
+		arguments:
+			checkFunctionNameCase: %checkFunctionNameCase%
 	- class: PHPStan\Rules\PHPUnit\NoMissingSpaceInClassAnnotationRule
 	- class: PHPStan\Rules\PHPUnit\NoMissingSpaceInMethodAnnotationRule
 

--- a/src/Rules/PHPUnit/DataProviderDeclarationRule.php
+++ b/src/Rules/PHPUnit/DataProviderDeclarationRule.php
@@ -29,13 +29,22 @@ class DataProviderDeclarationRule implements Rule
 	 */
 	private $fileTypeMapper;
 
+	/**
+	 * When set to true, it reports data provider method with incorrect name case.
+	 *
+	 * @var bool
+	 */
+	private $checkFunctionNameCase;
+
 	public function __construct(
 		DataProviderHelper $dataProviderHelper,
-		FileTypeMapper $fileTypeMapper
+		FileTypeMapper $fileTypeMapper,
+		bool $checkFunctionNameCase
 	)
 	{
 		$this->dataProviderHelper = $dataProviderHelper;
 		$this->fileTypeMapper = $fileTypeMapper;
+		$this->checkFunctionNameCase = $checkFunctionNameCase;
 	}
 
 	public function getNodeType(): string
@@ -71,7 +80,7 @@ class DataProviderDeclarationRule implements Rule
 		foreach ($annotations as $annotation) {
 			$errors = array_merge(
 				$errors,
-				$this->dataProviderHelper->processDataProvider($scope, $annotation)
+				$this->dataProviderHelper->processDataProvider($scope, $annotation, $this->checkFunctionNameCase)
 			);
 		}
 

--- a/src/Rules/PHPUnit/DataProviderDeclarationRule.php
+++ b/src/Rules/PHPUnit/DataProviderDeclarationRule.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\FileTypeMapper;
+use PHPUnit\Framework\TestCase;
+use function array_merge;
+
+/**
+ * @implements Rule<Node\Stmt\ClassMethod>
+ */
+class DataProviderDeclarationRule implements Rule
+{
+
+	/**
+	 * Data provider helper.
+	 *
+	 * @var DataProviderHelper
+	 */
+	private $dataProviderHelper;
+
+	/**
+	 * The file type mapper.
+	 *
+	 * @var FileTypeMapper
+	 */
+	private $fileTypeMapper;
+
+	public function __construct(
+		DataProviderHelper $dataProviderHelper,
+		FileTypeMapper $fileTypeMapper
+	)
+	{
+		$this->dataProviderHelper = $dataProviderHelper;
+		$this->fileTypeMapper = $fileTypeMapper;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\ClassMethod::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$classReflection = $scope->getClassReflection();
+
+		if ($classReflection === null || !$classReflection->isSubclassOf(TestCase::class)) {
+			return [];
+		}
+
+		$docComment = $node->getDocComment();
+		if ($docComment === null) {
+			return [];
+		}
+
+		$methodPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+			$scope->getFile(),
+			$classReflection->getName(),
+			$scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
+			$node->name->toString(),
+			$docComment->getText()
+		);
+
+		$annotations = $this->dataProviderHelper->getDataProviderAnnotations($methodPhpDoc);
+
+		$errors = [];
+
+		foreach ($annotations as $annotation) {
+			$errors = array_merge(
+				$errors,
+				$this->dataProviderHelper->processDataProvider($scope, $annotation)
+			);
+		}
+
+		return $errors;
+	}
+
+}

--- a/src/Rules/PHPUnit/DataProviderHelper.php
+++ b/src/Rules/PHPUnit/DataProviderHelper.php
@@ -11,7 +11,6 @@ use PHPStan\Rules\RuleErrorBuilder;
 use function array_merge;
 use function preg_match;
 use function sprintf;
-use function trim;
 
 class DataProviderHelper
 {
@@ -44,7 +43,8 @@ class DataProviderHelper
 	 */
 	public function processDataProvider(
 		Scope $scope,
-		PhpDocTagNode $phpDocTag
+		PhpDocTagNode $phpDocTag,
+		bool $checkFunctionNameCase
 	): array
 	{
 		$dataProviderName = $this->getDataProviderName($phpDocTag);
@@ -72,7 +72,7 @@ class DataProviderHelper
 
 		$errors = [];
 
-		if ($dataProviderName !== $dataProviderMethodReflection->getName()) {
+		if ($checkFunctionNameCase && $dataProviderName !== $dataProviderMethodReflection->getName()) {
 			$errors[] = RuleErrorBuilder::message(sprintf(
 				'@dataProvider %s related method is used with incorrect case: %s.',
 				$dataProviderName,
@@ -87,21 +87,12 @@ class DataProviderHelper
 			))->build();
 		}
 
-		if (!$dataProviderMethodReflection->isStatic()) {
-			$errors[] = RuleErrorBuilder::message(sprintf(
-				'@dataProvider %s related method must be static.',
-				$dataProviderName
-			))->build();
-		}
-
 		return $errors;
 	}
 
 	private function getDataProviderName(PhpDocTagNode $phpDocTag): ?string
 	{
-		$value = trim((string) $phpDocTag->value);
-
-		if (preg_match('/^[\S]+/', $value, $matches) !== 1) {
+		if (preg_match('/^[^ \t]+/', (string) $phpDocTag->value, $matches) !== 1) {
 			return null;
 		}
 

--- a/src/Rules/PHPUnit/DataProviderHelper.php
+++ b/src/Rules/PHPUnit/DataProviderHelper.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\Reflection\MissingMethodFromReflectionException;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use function array_merge;
+use function preg_match;
+use function sprintf;
+use function trim;
+
+class DataProviderHelper
+{
+
+	/**
+	 * @return array<PhpDocTagNode>
+	 */
+	public function getDataProviderAnnotations(?ResolvedPhpDocBlock $phpDoc): array
+	{
+		if ($phpDoc === null) {
+			return [];
+		}
+
+		$phpDocNodes = $phpDoc->getPhpDocNodes();
+
+		$annotations = [];
+
+		foreach ($phpDocNodes as $docNode) {
+			$annotations = array_merge(
+				$annotations,
+				$docNode->getTagsByName('@dataProvider')
+			);
+		}
+
+		return $annotations;
+	}
+
+	/**
+	 * @return RuleError[] errors
+	 */
+	public function processDataProvider(
+		Scope $scope,
+		PhpDocTagNode $phpDocTag
+	): array
+	{
+		$dataProviderName = $this->getDataProviderName($phpDocTag);
+		if ($dataProviderName === null) {
+			// Missing name is already handled in NoMissingSpaceInMethodAnnotationRule
+			return [];
+		}
+
+		$classReflection = $scope->getClassReflection();
+		if ($classReflection === null) {
+			// Should not happen
+			return [];
+		}
+
+		try {
+			$dataProviderMethodReflection = $classReflection->getNativeMethod($dataProviderName);
+		} catch (MissingMethodFromReflectionException $missingMethodFromReflectionException) {
+			$error = RuleErrorBuilder::message(sprintf(
+				'@dataProvider %s related method not found.',
+				$dataProviderName
+			))->build();
+
+			return [$error];
+		}
+
+		$errors = [];
+
+		if ($dataProviderName !== $dataProviderMethodReflection->getName()) {
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'@dataProvider %s related method is used with incorrect case: %s.',
+				$dataProviderName,
+				$dataProviderMethodReflection->getName()
+			))->build();
+		}
+
+		if (!$dataProviderMethodReflection->isPublic()) {
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'@dataProvider %s related method must be public.',
+				$dataProviderName
+			))->build();
+		}
+
+		if (!$dataProviderMethodReflection->isStatic()) {
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'@dataProvider %s related method must be static.',
+				$dataProviderName
+			))->build();
+		}
+
+		return $errors;
+	}
+
+	private function getDataProviderName(PhpDocTagNode $phpDocTag): ?string
+	{
+		$value = trim((string) $phpDocTag->value);
+
+		if (preg_match('/^[\S]+/', $value, $matches) !== 1) {
+			return null;
+		}
+
+		return $matches[0];
+	}
+
+}

--- a/tests/Rules/PHPUnit/DataProviderDeclarationRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDeclarationRuleTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+
+/**
+ * @extends RuleTestCase<DataProviderDeclarationRule>
+ */
+class DataProviderDeclarationRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new DataProviderDeclarationRule(
+			new DataProviderHelper(),
+			self::getContainer()->getByType(FileTypeMapper::class)
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/data-provider-declaration.php'], [
+			[
+				'@dataProvider providebaz related method is used with incorrect case: provideBaz.',
+				13,
+			],
+			[
+				'@dataProvider provideQux related method must be static.',
+				13,
+			],
+			[
+				'@dataProvider provideQuux related method must be public.',
+				13,
+			],
+			[
+				'@dataProvider provideNonExisting related method not found.',
+				66,
+			],
+		]);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../extension.neon',
+		];
+	}
+}

--- a/tests/Rules/PHPUnit/DataProviderDeclarationRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDeclarationRuleTest.php
@@ -16,7 +16,8 @@ class DataProviderDeclarationRuleTest extends RuleTestCase
 	{
 		return new DataProviderDeclarationRule(
 			new DataProviderHelper(),
-			self::getContainer()->getByType(FileTypeMapper::class)
+			self::getContainer()->getByType(FileTypeMapper::class),
+			true
 		);
 	}
 
@@ -25,10 +26,6 @@ class DataProviderDeclarationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/data-provider-declaration.php'], [
 			[
 				'@dataProvider providebaz related method is used with incorrect case: provideBaz.',
-				13,
-			],
-			[
-				'@dataProvider provideQux related method must be static.',
 				13,
 			],
 			[

--- a/tests/Rules/PHPUnit/data/data-provider-declaration.php
+++ b/tests/Rules/PHPUnit/data/data-provider-declaration.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace ExampleTestCase;
+
+class FooTestCase extends \PHPUnit\Framework\TestCase
+{
+	/**
+	 * @dataProvider provideBar Comment.
+	 * @dataProvider providebaz
+	 * @dataProvider provideQux
+	 * @dataProvider provideQuux
+	 */
+	public function testIsNotFoo(string $subject): void
+	{
+		self::assertNotSame('foo', $subject);
+	}
+
+	public static function provideBar(): iterable
+	{
+		return [
+			['bar'],
+		];
+	}
+
+	public static function provideBaz(): iterable
+	{
+		return [
+			['baz'],
+		];
+	}
+
+	public function provideQux(): iterable
+	{
+		return [
+			['qux'],
+		];
+	}
+
+	protected static function provideQuux(): iterable
+	{
+
+		return [
+			['quux'],
+		];
+	}
+}
+
+trait BarProvider
+{
+	public static function provideCorge(): iterable
+	{
+		return [
+			['corge'],
+		];
+	}
+}
+
+class BarTestCase extends \PHPUnit\Framework\TestCase
+{
+	use BarProvider;
+
+	/**
+	 * @dataProvider provideNonExisting
+	 * @dataProvider provideCorge
+	 */
+	public function testIsNotBar(string $subject): void
+	{
+		self::assertNotSame('bar', $subject);
+	}
+}


### PR DESCRIPTION
Here a new rule to check the `@dataProvider` annotation:
- does the method exist
- has the method the right case (depending on the `checkFunctionNameCase` parameter)
- is the method public
- ~is the method static~