### PR TITLE
Discover data providers from other classes

### DIFF
--- a/tests/Rules/PHPUnit/DataProviderDeclarationRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDeclarationRuleTest.php
@@ -27,19 +27,19 @@ class DataProviderDeclarationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/data-provider-declaration.php'], [
 			[
 				'@dataProvider providebaz related method is used with incorrect case: provideBaz.',
-				13,
+				14,
 			],
 			[
 				'@dataProvider provideQux related method must be static.',
-				13,
+				14,
 			],
 			[
 				'@dataProvider provideQuux related method must be public.',
-				13,
+				14,
 			],
 			[
 				'@dataProvider provideNonExisting related method not found.',
-				66,
+				67,
 			],
 		]);
 	}

--- a/tests/Rules/PHPUnit/data/data-provider-declaration.php
+++ b/tests/Rules/PHPUnit/data/data-provider-declaration.php
@@ -9,6 +9,7 @@ class FooTestCase extends \PHPUnit\Framework\TestCase
 	 * @dataProvider providebaz
 	 * @dataProvider provideQux
 	 * @dataProvider provideQuux
+	 * @dataProvider \ExampleTestCase\BarTestCase::provideToOtherClass
 	 */
 	public function testIsNotFoo(string $subject): void
 	{
@@ -66,5 +67,12 @@ class BarTestCase extends \PHPUnit\Framework\TestCase
 	public function testIsNotBar(string $subject): void
 	{
 		self::assertNotSame('bar', $subject);
+	}
+
+	public static function provideToOtherClass(): iterable
+	{
+		return [
+			['toOtherClass'],
+		];
 	}
 }


### PR DESCRIPTION
Until 1.2.2 such code (working well) was correctly not reported:
```php
<?php
namespace Tests;
class FooTest extends TestCase
{
    public static function fooProvider(): iterable
    {
        /* ... */
    }
}
```
```php
<?php
namespace Tests;
class BarTest extends TestCase
{
    /**
     * @dataProvider \Tests\FooTest::fooProvider
     */
    public function testStuff(... $arguments): void
    {
        /* ... */
    }
}
````

(see failing job at https://github.com/kubawerlos/php-cs-fixer-custom-fixers/pull/849)
