### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,13 +2,12 @@
 *.stub linguist-language=PHP
 *.neon linguist-language=YAML
 
-.github export-ignore
-tests export-ignore
-tmp export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-Makefile export-ignore
-phpcs.xml export-ignore
-phpstan.neon export-ignore
-phpstan-baseline.neon export-ignore
-phpunit.xml export-ignore
+/.* export-ignore
+/build-cs export-ignore
+/tests export-ignore
+/tmp export-ignore
+/Makefile export-ignore
+/phpcs.xml export-ignore
+/phpstan.neon export-ignore
+/phpstan-baseline.neon export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
This PR:

 - adds a leading slash to all `export-ignore` entries
 - adds `/.*` which will match `.editorconfig` that previously was not excluded
 - excludes `build-cs` directory