### PR TITLE
Add tip to error when a not fully qualified name is seen in @covers annotation.

### DIFF
--- a/src/Rules/PHPUnit/CoversHelper.php
+++ b/src/Rules/PHPUnit/CoversHelper.php
@@ -105,11 +105,17 @@ class CoversHelper
 				return $errors;
 			}
 
-			$errors[] = RuleErrorBuilder::message(sprintf(
+			$error = RuleErrorBuilder::message(sprintf(
 				'@covers value %s references an invalid %s.',
 				$fullName,
 				$isMethod ? 'method' : 'class or function'
-			))->build();
+			));
+
+			if (strpos($className, '\\') === false) {
+				$error->tip('The @covers annotation requires a fully qualified name.');
+			}
+
+			$errors[] = $error->build();
 		}
 		return $errors;
 	}

--- a/tests/Rules/PHPUnit/ClassCoversExistsRuleTest.php
+++ b/tests/Rules/PHPUnit/ClassCoversExistsRuleTest.php
@@ -40,6 +40,11 @@ class ClassCoversExistsRuleTest extends RuleTestCase
 				'@covers value does not specify anything.',
 				43,
 			],
+			[
+				'@covers value NotFullyQualified references an invalid class or function.',
+				50,
+				'The @covers annotation requires a fully qualified name.',
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/data/class-coverage.php
+++ b/tests/Rules/PHPUnit/data/class-coverage.php
@@ -43,3 +43,10 @@ function testable(): void
 class CoversNothing extends \PHPUnit\Framework\TestCase
 {
 }
+
+/**
+ * @covers NotFullyQualified
+ */
+class CoversNotFullyQualified extends \PHPUnit\Framework\TestCase
+{
+}


### PR DESCRIPTION
This is a mistake i see made fairly often and is only raised as an issue by phpunit when actually generating coverage reports, which is often only done in ci and not when running locally, so would be great to give the feedback sooner.