### PR TITLE
Fixed false positive when covering a global function.

### DIFF
--- a/src/Rules/PHPUnit/CoversHelper.php
+++ b/src/Rules/PHPUnit/CoversHelper.php
@@ -71,6 +71,13 @@ class CoversHelper
 	{
 		$errors = [];
 		$covers = (string) $phpDocTag->value;
+
+		if ($covers === '') {
+			$errors[] = RuleErrorBuilder::message('@covers value does not specify anything.')->build();
+
+			return $errors;
+		}
+
 		$isMethod = strpos($covers, '::') !== false;
 		$fullName = $covers;
 
@@ -94,17 +101,12 @@ class CoversHelper
 					$fullName
 				))->build();
 			}
+		} elseif (isset($method) && $this->reflectionProvider->hasFunction(new Name($method, []), null)) {
+			return $errors;
+		} elseif (!isset($method) && $this->reflectionProvider->hasFunction(new Name($className, []), null)) {
+			return $errors;
+
 		} else {
-			if ($covers === '') {
-				$errors[] = RuleErrorBuilder::message('@covers value does not specify anything.')->build();
-
-				return $errors;
-			}
-
-			if (!isset($method) && $this->reflectionProvider->hasFunction(new Name($covers, []), null)) {
-				return $errors;
-			}
-
 			$error = RuleErrorBuilder::message(sprintf(
 				'@covers value %s references an invalid %s.',
 				$fullName,

--- a/tests/Rules/PHPUnit/data/class-coverage.php
+++ b/tests/Rules/PHPUnit/data/class-coverage.php
@@ -50,3 +50,10 @@ class CoversNothing extends \PHPUnit\Framework\TestCase
 class CoversNotFullyQualified extends \PHPUnit\Framework\TestCase
 {
 }
+
+/**
+ * @covers ::str_replace
+ */
+class CoversGlobalFunction extends \PHPUnit\Framework\TestCase
+{
+}


### PR DESCRIPTION
Previously this case wasn't tested and was overlooked as phpstan test data files are namespaced, but this cropped up today during rollout of the rules and so i've had to `@covers` a php built-in to cover the case in a test

also moved the "doesn't specify anything" test up in the code as it's a fail-fast path, dunno why i put it where i did in the first place, time pressure probably

thanks for your time