### PR TITLE
Warn when trying to cover an interface.

### DIFF
--- a/src/Rules/PHPUnit/CoversHelper.php
+++ b/src/Rules/PHPUnit/CoversHelper.php
@@ -95,6 +95,13 @@ class CoversHelper
 		if ($this->reflectionProvider->hasClass($className)) {
 			$class = $this->reflectionProvider->getClass($className);
 
+			if ($class->isInterface()) {
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'@covers value %s references an interface.',
+					$fullName
+				))->build();
+			}
+
 			if (isset($method) && $method !== '' && !$class->hasMethod($method)) {
 				$errors[] = RuleErrorBuilder::message(sprintf(
 					'@covers value %s references an invalid method.',
@@ -105,7 +112,6 @@ class CoversHelper
 			return $errors;
 		} elseif (!isset($method) && $this->reflectionProvider->hasFunction(new Name($className, []), null)) {
 			return $errors;
-
 		} else {
 			$error = RuleErrorBuilder::message(sprintf(
 				'@covers value %s references an invalid %s.',

--- a/tests/Rules/PHPUnit/ClassCoversExistsRuleTest.php
+++ b/tests/Rules/PHPUnit/ClassCoversExistsRuleTest.php
@@ -45,6 +45,10 @@ class ClassCoversExistsRuleTest extends RuleTestCase
 				50,
 				'The @covers annotation requires a fully qualified name.',
 			],
+			[
+				'@covers value \DateTimeInterface references an interface.',
+				64,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/data/class-coverage.php
+++ b/tests/Rules/PHPUnit/data/class-coverage.php
@@ -57,3 +57,10 @@ class CoversNotFullyQualified extends \PHPUnit\Framework\TestCase
 class CoversGlobalFunction extends \PHPUnit\Framework\TestCase
 {
 }
+
+/**
+ * @covers \DateTimeInterface
+ */
+class CoversInterface extends \PHPUnit\Framework\TestCase
+{
+}


### PR DESCRIPTION
phpunit 10.x errors when attempting to `@covers` an interface, so phpstan can warn about that case early