### PR TITLE
Add partial support for assertContainsOnlyInstancesOf

### DIFF
--- a/tests/Type/PHPUnit/data/assert-function.php
+++ b/tests/Type/PHPUnit/data/assert-function.php
@@ -4,6 +4,7 @@ namespace AssertFunction;
 
 use function PHPStan\Testing\assertType;
 use function PHPUnit\Framework\assertArrayHasKey;
+use function PHPUnit\Framework\assertContainsOnlyInstancesOf;
 use function PHPUnit\Framework\assertEmpty;
 use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertObjectHasAttribute;
@@ -41,6 +42,15 @@ class Foo
 	{
 		assertEmpty($a);
 		assertType("0|0.0|''|'0'|array{}|Countable|EmptyIterator|false|null", $a);
+	}
+
+	public function containsOnlyInstancesOf(array $a, \Traversable $b): void
+	{
+		assertContainsOnlyInstancesOf(\stdClass::class, $a);
+		assertType('array<stdClass>', $a);
+
+		assertContainsOnlyInstancesOf(\stdClass::class, $b);
+		assertType('Traversable', $b);
 	}
 
 }


### PR DESCRIPTION
Add support for [assertContainsOnlyInstancesOf](https://docs.phpunit.de/en/9.5/assertions.html#assertcontainsonlyinstancesof) when the 2nd argument is an array.
The behaviour is not changed when it is an instance of *Traversable*.

See #158