### PR TITLE
Microoptimize AssertRuleHelper.

### DIFF
--- a/src/Rules/PHPUnit/AssertRuleHelper.php
+++ b/src/Rules/PHPUnit/AssertRuleHelper.php
@@ -16,7 +16,6 @@ class AssertRuleHelper
 	 */
 	public static function isMethodOrStaticCallOnAssert(Node $node, Scope $scope): bool
 	{
-		$testCaseType = new ObjectType('PHPUnit\Framework\Assert');
 		if ($node instanceof Node\Expr\MethodCall) {
 			$calledOnType = $scope->getType($node->var);
 		} elseif ($node instanceof Node\Expr\StaticCall) {
@@ -45,11 +44,9 @@ class AssertRuleHelper
 			return false;
 		}
 
-		if (!$testCaseType->isSuperTypeOf($calledOnType)->yes()) {
-			return false;
-		}
+		$testCaseType = new ObjectType('PHPUnit\Framework\Assert');
 
-		return true;
+		return $testCaseType->isSuperTypeOf($calledOnType)->yes();
 	}
 
 }


### PR DESCRIPTION
minor micro-opts to AssertRuleHelper

this static method is called multiple times for every ast node analysed currently due to the rules that use it specifying `NodeAbstract` as their node type
