### PR TITLE
Add support for `assertObjectHasProperty`

### DIFF
--- a/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
+++ b/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
@@ -276,6 +276,9 @@ class AssertTypeSpecifyingExtensionHelper
 				'ObjectHasAttribute' => static function (Scope $scope, Arg $property, Arg $object): FuncCall {
 					return new FuncCall(new Name('property_exists'), [$object, $property]);
 				},
+				'ObjectHasProperty' => static function (Scope $scope, Arg $property, Arg $object): FuncCall {
+					return new FuncCall(new Name('property_exists'), [$object, $property]);
+				},
 				'Contains' => static function (Scope $scope, Arg $needle, Arg $haystack): Expr {
 					return new Expr\BinaryOp\BooleanOr(
 						new Expr\Instanceof_($haystack->value, new Name('Traversable')),

--- a/tests/Type/PHPUnit/AssertFunctionTypeSpecifyingExtensionTest.php
+++ b/tests/Type/PHPUnit/AssertFunctionTypeSpecifyingExtensionTest.php
@@ -11,17 +11,15 @@ class AssertFunctionTypeSpecifyingExtensionTest extends TypeInferenceTestCase
 	/** @return mixed[] */
 	public function dataFileAsserts(): iterable
 	{
-		if (!function_exists('PHPUnit\\Framework\\assertInstanceOf')) {
-			return [];
+		if (function_exists('PHPUnit\\Framework\\assertInstanceOf')) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-function.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-function.php');
-
-		if (!function_exists('PHPUnit\\Framework\\assertObjectHasProperty')) {
-			return [];
+		if (function_exists('PHPUnit\\Framework\\assertObjectHasProperty')) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-function-9.6.11.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-function-9.6.11.php');
+		return [];
 	}
 
 	/**

--- a/tests/Type/PHPUnit/AssertFunctionTypeSpecifyingExtensionTest.php
+++ b/tests/Type/PHPUnit/AssertFunctionTypeSpecifyingExtensionTest.php
@@ -16,6 +16,12 @@ class AssertFunctionTypeSpecifyingExtensionTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-function.php');
+
+		if (!function_exists('PHPUnit\\Framework\\assertObjectHasProperty')) {
+			return [];
+		}
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-function-9.6.11.php');
 	}
 
 	/**

--- a/tests/Type/PHPUnit/data/assert-function-9.6.11.php
+++ b/tests/Type/PHPUnit/data/assert-function-9.6.11.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AssertFunction;
+
+use function PHPStan\Testing\assertType;
+use function PHPUnit\Framework\assertObjectHasProperty;
+
+class Foo
+{
+
+	public function objectHasProperty(object $a): void
+	{
+		assertObjectHasProperty('property', $a);
+		assertType("object&hasProperty(property)", $a);
+	}
+
+}

--- a/tests/Type/PHPUnit/data/assert-function.php
+++ b/tests/Type/PHPUnit/data/assert-function.php
@@ -10,6 +10,7 @@ use function PHPUnit\Framework\assertContainsOnlyInstancesOf;
 use function PHPUnit\Framework\assertEmpty;
 use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertObjectHasAttribute;
+use function PHPUnit\Framework\assertObjectHasProperty;
 
 class Foo
 {
@@ -54,6 +55,12 @@ class Foo
 	public function objectHasAttribute(object $a): void
 	{
 		assertObjectHasAttribute('property', $a);
+		assertType("object&hasProperty(property)", $a);
+	}
+
+	public function objectHasProperty(object $a): void
+	{
+		assertObjectHasProperty('property', $a);
 		assertType("object&hasProperty(property)", $a);
 	}
 

--- a/tests/Type/PHPUnit/data/assert-function.php
+++ b/tests/Type/PHPUnit/data/assert-function.php
@@ -10,7 +10,6 @@ use function PHPUnit\Framework\assertContainsOnlyInstancesOf;
 use function PHPUnit\Framework\assertEmpty;
 use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertObjectHasAttribute;
-use function PHPUnit\Framework\assertObjectHasProperty;
 
 class Foo
 {
@@ -55,12 +54,6 @@ class Foo
 	public function objectHasAttribute(object $a): void
 	{
 		assertObjectHasAttribute('property', $a);
-		assertType("object&hasProperty(property)", $a);
-	}
-
-	public function objectHasProperty(object $a): void
-	{
-		assertObjectHasProperty('property', $a);
 		assertType("object&hasProperty(property)", $a);
 	}
 


### PR DESCRIPTION
[Added in PHPUnit 9.6.11](https://github.com/sebastianbergmann/phpunit/blob/9.6/ChangeLog-9.6.md#9611---2023-08-19) as a forward-compatibility.