### PR TITLE
AssertTypeSpecifyingExtensionHelper: rootExpr with unknown variable to avoid always-true false positives

### DIFF
--- a/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
+++ b/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
@@ -90,7 +90,8 @@ class AssertTypeSpecifyingExtensionHelper
 		return $typeSpecifier->specifyTypesInCondition(
 			$scope,
 			$expression,
-			TypeSpecifierContext::createTruthy()
+			TypeSpecifierContext::createTruthy(),
+			new Expr\BinaryOp\BooleanAnd($expression, new Expr\Variable(new Name('nonsense')))
 		);
 	}
 

--- a/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
+++ b/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
@@ -23,6 +23,7 @@ use PHPStan\Analyser\TypeSpecifierContext;
 use ReflectionObject;
 use function array_key_exists;
 use function count;
+use function in_array;
 use function strlen;
 use function strpos;
 use function substr;

--- a/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
+++ b/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
@@ -91,7 +91,7 @@ class AssertTypeSpecifyingExtensionHelper
 			$scope,
 			$expression,
 			TypeSpecifierContext::createTruthy(),
-			new Expr\BinaryOp\BooleanAnd($expression, new Expr\Variable(new Name('nonsense')))
+			new Expr\BinaryOp\BooleanAnd($expression, new Expr\Variable('nonsense'))
 		);
 	}
 

--- a/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
+++ b/src/Type/PHPUnit/Assert/AssertTypeSpecifyingExtensionHelper.php
@@ -34,6 +34,12 @@ class AssertTypeSpecifyingExtensionHelper
 	private static $resolvers;
 
 	/**
+	 * Those can specify types correctly, but would produce always-true issue
+	 * @var string[]
+	 */
+	private static $resolversCausingAlwaysTrue = ['ContainsOnlyInstancesOf', 'ContainsEquals', 'Contains'];
+
+	/**
 	 * @param Arg[] $args
 	 */
 	public static function isSupported(
@@ -87,11 +93,14 @@ class AssertTypeSpecifyingExtensionHelper
 		if ($expression === null) {
 			return new SpecifiedTypes([], []);
 		}
+
+		$bypassAlwaysTrueIssue = in_array(self::trimName($name), self::$resolversCausingAlwaysTrue, true);
+
 		return $typeSpecifier->specifyTypesInCondition(
 			$scope,
 			$expression,
 			TypeSpecifierContext::createTruthy(),
-			new Expr\BinaryOp\BooleanAnd($expression, new Expr\Variable('nonsense'))
+			$bypassAlwaysTrueIssue ? new Expr\BinaryOp\BooleanAnd($expression, new Expr\Variable('nonsense')) : null
 		);
 	}
 

--- a/tests/Rules/PHPUnit/data/assert-same.php
+++ b/tests/Rules/PHPUnit/data/assert-same.php
@@ -65,6 +65,13 @@ class FooTestCase extends \PHPUnit\Framework\TestCase
 		$foo->assertSame();
 	}
 
+	public function testAssertContains()
+	{
+		$this->assertContains('not in the list', new \ArrayObject([1]));
+		$this->assertContainsEquals('not in the list', new \ArrayObject([1]));
+		$this->assertNotContains('not in the list', new \ArrayObject([1]));
+	}
+
 	public function testStaticMethodReturnWithSameTypeIsNotReported()
 	{
 		$this->assertSame(self::createSomething('foo'), self::createSomething('foo'));


### PR DESCRIPTION
This should fix https://github.com/phpstan/phpstan-phpunit/issues/193.