### PR TITLE
Addition of rule for cases better represented with assertSameSize() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It also contains this strict framework-specific rules (can be enabled separately
 * Check that you are not using `assertSame()` with `false` as expected value. `assertFalse()` should be used instead.
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
 * Check that you are not using `assertSame()` with `count($variable)` as second parameter. `assertCount($variable)` should be used instead.
+  * if you enable [bleedingEdge](/blog/what-is-bleeding-edge), check that you are not using `assertSame()` with `count($variable)` as first and second parameter. `assertSameSize()`should be used instead.
 
 ## How to document mock objects in phpDocs?
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It also contains this strict framework-specific rules (can be enabled separately
 * Check that you are not using `assertSame()` with `false` as expected value. `assertFalse()` should be used instead.
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
 * Check that you are not using `assertSame()` with `count($variable)` as second parameter. `assertCount($variable)` should be used instead.
-  * if you enable [bleedingEdge](/blog/what-is-bleeding-edge), check that you are not using `assertSame()` with `count($variable)` as first and second parameter. `assertSameSize()`should be used instead.
+  * If you enable [bleeding edge](https://phpstan.org/blog/what-is-bleeding-edge), check that you are not using `assertSame()` with `count($variable)` as first and second parameter. `assertSameSize()`should be used instead.
 
 ## How to document mock objects in phpDocs?
 

--- a/rules.neon
+++ b/rules.neon
@@ -1,11 +1,16 @@
 rules:
 	- PHPStan\Rules\PHPUnit\AssertSameBooleanExpectedRule
 	- PHPStan\Rules\PHPUnit\AssertSameNullExpectedRule
-	- PHPStan\Rules\PHPUnit\AssertSameWithCountRule
 	- PHPStan\Rules\PHPUnit\MockMethodCallRule
 	- PHPStan\Rules\PHPUnit\ShouldCallParentMethodsRule
 
 services:
+	-
+		class: PHPStan\Rules\PHPUnit\AssertSameWithCountRule
+		arguments:
+			bleedingEdge: %featureToggles.bleedingEdge%
+		tags:
+			- phpstan.rules.rule
 	- class: PHPStan\Rules\PHPUnit\ClassCoversExistsRule
 	- class: PHPStan\Rules\PHPUnit\ClassMethodCoversExistsRule
 	-

--- a/tests/Rules/PHPUnit/AssertSameWithCountRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertSameWithCountRuleTest.php
@@ -13,7 +13,7 @@ class AssertSameWithCountRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new AssertSameWithCountRule();
+		return new AssertSameWithCountRule(true);
 	}
 
 	public function testRule(): void
@@ -24,12 +24,28 @@ class AssertSameWithCountRuleTest extends RuleTestCase
 				10,
 			],
 			[
+				'You should use assertSameSize($expected, $variable) instead of assertSame(count($expected), count($variable)).',
+				15,
+			],
+			[
+				'You should use assertSameSize($expected, $variable) instead of assertSame($expected->count(), count($variable)).',
+				23,
+			],
+			[
 				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, count($variable)).',
-				22,
+				35,
 			],
 			[
 				'You should use assertCount($expectedCount, $variable) instead of assertSame($expectedCount, $variable->count()).',
-				30,
+				43,
+			],
+			[
+				'You should use assertSameSize($expected, $variable) instead of assertSame(count($expected), $variable->count()).',
+				51,
+			],
+			[
+				'You should use assertSameSize($expected, $variable) instead of assertSame($expected->count(), $variable->count()).',
+				61,
 			],
 		]);
 	}

--- a/tests/Rules/PHPUnit/data/assert-same-count.php
+++ b/tests/Rules/PHPUnit/data/assert-same-count.php
@@ -10,6 +10,19 @@ class AssertSameWithCountTestCase extends \PHPUnit\Framework\TestCase
 		$this->assertSame(5, count([1, 2, 3]));
 	}
 
+	public function testAssertSameWithCountExpectedWithCount()
+	{
+		$this->assertSame(count([10, 20]), count([1, 2, 3]));
+	}
+
+	public function testAssertSameWithCountExpectedMethodWithCountMethod()
+	{
+		$foo = new \stdClass();
+		$foo->bar = new Bar ();
+
+		$this->assertSame($foo->bar->count(), count([1, 2, 3]));
+	}
+
 	public function testAssertSameWithCountMethodIsOK()
 	{
 		$foo = new \stdClass();
@@ -28,6 +41,24 @@ class AssertSameWithCountTestCase extends \PHPUnit\Framework\TestCase
 		$foo->bar = new Bar ();
 
 		$this->assertSame(5, $foo->bar->count());
+	}
+
+	public function testAssertSameWithCountExpectedWithCountMethodForCountableVariableIsNot()
+	{
+		$foo = new \stdClass();
+		$foo->bar = new Bar ();
+
+		$this->assertSame(count([10, 20]), $foo->bar->count());
+	}
+
+	public function testAssertSameWithCountExpectedMethodWithCountMethodForCountableVariableIsNot()
+	{
+		$foo = new \stdClass();
+		$foo->bar = new Bar ();
+		$foo2 = new \stdClass();
+		$foo2->bar = new Bar ();
+
+		$this->assertSame($foo2->bar->count(), $foo->bar->count());
 	}
 
 }


### PR DESCRIPTION
This Pull Request enhances the AssertSameWithCountRule in PHPUnit to handle additional use cases. The new rule now checks when both sides of the assertSame are counts, and suggests assertSameSize instead when necessary.

Here is some detail on what has changed:
* AssertSameWithCountRule now includes a check for cases where expected value of assertCount is the direct result of count function call.
* In these cases, a special assertion function assertSameSize is suggested to compare the sizes of collections rather than using the original assertSame function.

The code changes involve adjustments in method call structures, evaluation of counts and introduction of cases for assertSameSize.