### PR TITLE
fix: Make sure Assert::assertIsList correctly asserts an array as list

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -9,6 +9,9 @@ parameters:
 			- markTestIncomplete
 			- markTestSkipped
 	stubFiles:
+		- stubs/Assert.stub
+		- stubs/AssertionFailedError.stub
+		- stubs/ExpectationFailedException.stub
 		- stubs/InvocationMocker.stub
 		- stubs/MockBuilder.stub
 		- stubs/MockObject.stub

--- a/stubs/Assert.stub
+++ b/stubs/Assert.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPUnit\Framework;
+
+abstract class Assert
+{
+    /**
+     * @phpstan-assert list $array
+     *
+     * @throws ExpectationFailedException
+     */
+    final public static function assertIsList(mixed $array, string $message = ''): void {}
+}

--- a/stubs/AssertionFailedError.stub
+++ b/stubs/AssertionFailedError.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace PHPUnit\Framework;
+
+class AssertionFailedError extends \Exception
+{
+
+}

--- a/stubs/ExpectationFailedException.stub
+++ b/stubs/ExpectationFailedException.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace PHPUnit\Framework;
+
+final class ExpectationFailedException extends AssertionFailedError
+{
+
+}


### PR DESCRIPTION
Follow up of this issue: https://github.com/phpstan/phpstan-phpunit/issues/212

I decided to also bring this up into this repo, to make sure it also works for older PHPUnit versions. 

for PHPUnit 11 it is fixed here: https://github.com/sebastianbergmann/phpunit/pull/6027

but the `phpstan-assert` annotations are not used in older versions. I hope this is okay.

I also add it to the 1.4.x branch, is we could not update to 2.x yet, because of missing plugin compatibility. 