### PR TITLE
Implement AssertEqualsIsDiscouragedRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It also contains this strict framework-specific rules (can be enabled separately
 * Check that you are not using `assertSame()` with `false` as expected value. `assertFalse()` should be used instead.
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
 * Check that you are not using `assertSame()` with `count($variable)` as second parameter. `assertCount($variable)` should be used instead.
+* Check that you are not using `assertEquals()` with same types (`assertSame()` should be used)
 
 ## How to document mock objects in phpDocs?
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^2.0"
+		"phpstan/phpstan": "^2.0.4"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"

--- a/rules.neon
+++ b/rules.neon
@@ -2,6 +2,7 @@ rules:
 	- PHPStan\Rules\PHPUnit\AssertSameBooleanExpectedRule
 	- PHPStan\Rules\PHPUnit\AssertSameNullExpectedRule
 	- PHPStan\Rules\PHPUnit\AssertSameWithCountRule
+	- PHPStan\Rules\PHPUnit\AssertEqualsIsDiscouragedRule
 	- PHPStan\Rules\PHPUnit\ClassCoversExistsRule
 	- PHPStan\Rules\PHPUnit\ClassMethodCoversExistsRule
 	- PHPStan\Rules\PHPUnit\MockMethodCallRule

--- a/rules.neon
+++ b/rules.neon
@@ -2,7 +2,6 @@ rules:
 	- PHPStan\Rules\PHPUnit\AssertSameBooleanExpectedRule
 	- PHPStan\Rules\PHPUnit\AssertSameNullExpectedRule
 	- PHPStan\Rules\PHPUnit\AssertSameWithCountRule
-	- PHPStan\Rules\PHPUnit\AssertEqualsIsDiscouragedRule
 	- PHPStan\Rules\PHPUnit\ClassCoversExistsRule
 	- PHPStan\Rules\PHPUnit\ClassMethodCoversExistsRule
 	- PHPStan\Rules\PHPUnit\MockMethodCallRule
@@ -16,5 +15,12 @@ services:
 		arguments:
 			checkFunctionNameCase: %checkFunctionNameCase%
 			deprecationRulesInstalled: %deprecationRulesInstalled%
+		tags:
+			- phpstan.rules.rule
+
+	-
+		class: PHPStan\Rules\PHPUnit\AssertEqualsIsDiscouragedRule
+		arguments:
+			strictRulesInstalled: %strictRulesInstalled%
 		tags:
 			- phpstan.rules.rule

--- a/rules.neon
+++ b/rules.neon
@@ -9,6 +9,10 @@ rules:
 	- PHPStan\Rules\PHPUnit\NoMissingSpaceInMethodAnnotationRule
 	- PHPStan\Rules\PHPUnit\ShouldCallParentMethodsRule
 
+conditionalTags:
+	PHPStan\Rules\PHPUnit\AssertEqualsIsDiscouragedRule:
+		phpstan.rules.rule: [%strictRulesInstalled%, %featureToggles.bleedingEdge%]
+
 services:
 	-
 		class: PHPStan\Rules\PHPUnit\DataProviderDeclarationRule
@@ -20,7 +24,3 @@ services:
 
 	-
 		class: PHPStan\Rules\PHPUnit\AssertEqualsIsDiscouragedRule
-		arguments:
-			strictRulesInstalled: %strictRulesInstalled%
-		tags:
-			- phpstan.rules.rule

--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -3,7 +3,7 @@
 namespace PHPStan\Rules\PHPUnit;
 
 use PhpParser\Node;
-use PhpParser\NodeAbstract;
+use PhpParser\Node\Expr\CallLike;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -13,14 +13,14 @@ use function count;
 use function strtolower;
 
 /**
- * @implements Rule<NodeAbstract>
+ * @implements Rule<CallLike>
  */
 class AssertEqualsIsDiscouragedRule implements Rule
 {
 
 	public function getNodeType(): string
 	{
-		return NodeAbstract::class;
+		return CallLike::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array

--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -18,15 +18,6 @@ use function strtolower;
 class AssertEqualsIsDiscouragedRule implements Rule
 {
 
-	private bool $strictRulesInstalled;
-
-	public function __construct(
-		bool $strictRulesInstalled
-	)
-	{
-		$this->strictRulesInstalled = $strictRulesInstalled;
-	}
-
 	public function getNodeType(): string
 	{
 		return NodeAbstract::class;
@@ -34,10 +25,6 @@ class AssertEqualsIsDiscouragedRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$this->strictRulesInstalled) {
-			return [];
-		}
-
 		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
 			return [];
 		}

--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -18,6 +18,15 @@ use function strtolower;
 class AssertEqualsIsDiscouragedRule implements Rule
 {
 
+	private bool $strictRulesInstalled;
+
+	public function __construct(
+		bool $strictRulesInstalled
+	)
+	{
+		$this->strictRulesInstalled = $strictRulesInstalled;
+	}
+
 	public function getNodeType(): string
 	{
 		return NodeAbstract::class;
@@ -25,6 +34,10 @@ class AssertEqualsIsDiscouragedRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if (!$this->strictRulesInstalled) {
+			return [];
+		}
+
 		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
 			return [];
 		}

--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PhpParser\Node;
+use PhpParser\NodeAbstract;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\GeneralizePrecision;
+use PHPStan\Type\TypeCombinator;
+use function count;
+use function strtolower;
+
+/**
+ * @implements Rule<NodeAbstract>
+ */
+class AssertEqualsIsDiscouragedRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return NodeAbstract::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
+			return [];
+		}
+
+		if (count($node->getArgs()) < 2) {
+			return [];
+		}
+		if (!$node->name instanceof Node\Identifier || strtolower($node->name->name) !== 'assertequals') {
+			return [];
+		}
+
+		$leftType = TypeCombinator::removeNull($scope->getType($node->getArgs()[0]->value));
+		$rightType = TypeCombinator::removeNull($scope->getType($node->getArgs()[1]->value));
+
+		if ($leftType->isConstantScalarValue()->yes()) {
+			$leftType = $leftType->generalize(GeneralizePrecision::lessSpecific());
+		}
+		if ($rightType->isConstantScalarValue()->yes()) {
+			$rightType = $rightType->generalize(GeneralizePrecision::lessSpecific());
+		}
+
+		if (
+			($leftType->isScalar()->yes() && $rightType->isScalar()->yes())
+			&& ($leftType->isSuperTypeOf($rightType)->yes())
+			&& ($rightType->isSuperTypeOf($leftType)->yes())
+		) {
+			return [
+				RuleErrorBuilder::message(
+					'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type',
+				)->identifier('phpunit.assertEquals')->build(),
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<AssertEqualsIsDiscouragedRule>
+ */
+final class AssertEqualsIsDiscouragedRuleTest extends RuleTestCase
+{
+
+	private const ERROR_MESSAGE = 'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type';
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/assert-equals-is-discouraged.php'], [
+			[self::ERROR_MESSAGE, 19],
+			[self::ERROR_MESSAGE, 22],
+			[self::ERROR_MESSAGE, 23],
+			[self::ERROR_MESSAGE, 24],
+			[self::ERROR_MESSAGE, 25],
+			[self::ERROR_MESSAGE, 26],
+			[self::ERROR_MESSAGE, 27],
+			[self::ERROR_MESSAGE, 28],
+			[self::ERROR_MESSAGE, 29],
+			[self::ERROR_MESSAGE, 30],
+			[self::ERROR_MESSAGE, 32],
+		]);
+	}
+
+	protected function getRule(): Rule
+	{
+		return new AssertEqualsIsDiscouragedRule();
+	}
+
+}

--- a/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
@@ -32,7 +32,7 @@ final class AssertEqualsIsDiscouragedRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new AssertEqualsIsDiscouragedRule();
+		return new AssertEqualsIsDiscouragedRule(true);
 	}
 
 }

--- a/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
@@ -32,7 +32,7 @@ final class AssertEqualsIsDiscouragedRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new AssertEqualsIsDiscouragedRule(true);
+		return new AssertEqualsIsDiscouragedRule();
 	}
 
 }

--- a/tests/Rules/PHPUnit/data/assert-equals-is-discouraged.php
+++ b/tests/Rules/PHPUnit/data/assert-equals-is-discouraged.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SameOverEqualsTest;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+final class AssertSameOverAssertEqualsRule extends TestCase
+{
+	public function dummyTest(string $string, int $integer,	bool $boolean, float $float, ?string $nullableString): void
+	{
+		$null = null;
+
+		$this->assertSame(5, $integer);
+		static::assertSame(5, $integer);
+
+		$this->assertEquals('', $string);
+		$this->assertEquals(null, $string);
+		static::assertEquals(null, $string);
+		static::assertEquals($nullableString, $string);
+		$this->assertEquals(2, $integer);
+		$this->assertEquals(2.2, $float);
+		static::assertEquals((int) '2', (int) $string);
+		$this->assertEquals(true, $boolean);
+		$this->assertEquals($string, $string);
+		$this->assertEquals($integer, $integer);
+		$this->assertEquals($boolean, $boolean);
+		$this->assertEquals($float, $float);
+		$this->assertEquals($null, $null);
+		$this->assertEquals((string) new Exception(), (string) new Exception());
+		$this->assertEquals([], []);
+		$this->assertEquals(new Exception(), new Exception());
+		static::assertEquals(new Exception(), new Exception());
+	}
+}


### PR DESCRIPTION
Simplified version which is concentrated on the main point: point people to `assertSame` when possible.
I intentionally stripped of the "assertEquals is fine when a comment is given" case, as I think its not important.

closes https://github.com/phpstan/phpstan-phpunit/pull/6

refs https://github.com/phpstan/phpstan-phpunit/issues/7