### PR TITLE
Fix error message for "assertNotEquals" usage referencing "assertSame" and "assertEquals"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It also contains this strict framework-specific rules (can be enabled separately
 * Check that you are not using `assertSame()` with `null` as expected value. `assertNull()` should be used instead.
 * Check that you are not using `assertSame()` with `count($variable)` as second parameter. `assertCount($variable)` should be used instead.
 * Check that you are not using `assertEquals()` with same types (`assertSame()` should be used)
+* Check that you are not using `assertNotEquals()` with same types (`assertNotSame()` should be used)
 
 ## How to document mock objects in phpDocs?
 

--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -11,6 +11,7 @@ use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\TypeCombinator;
 use function count;
 use function in_array;
+use function sprintf;
 use function strtolower;
 
 /**
@@ -55,17 +56,13 @@ class AssertEqualsIsDiscouragedRule implements Rule
 			&& ($leftType->isSuperTypeOf($rightType)->yes())
 			&& ($rightType->isSuperTypeOf($leftType)->yes())
 		) {
-			if (strtolower($node->name->name) === 'assertnotequals') {
-				return [
-					RuleErrorBuilder::message(
-						'You should use assertNotSame() instead of assertNotEquals(), because both values are scalars of the same type',
-					)->identifier('phpunit.assertEquals')->build(),
-				];
-			}
-
 			return [
 				RuleErrorBuilder::message(
-					'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type',
+					sprintf(
+						'You should use %s() instead of %s(), because both values are scalars of the same type',
+						strtolower($node->name->name) === 'assertnotequals' ? 'assertNotSame' : 'assertSame',
+						$node->name->name,
+					),
 				)->identifier('phpunit.assertEquals')->build(),
 			];
 		}

--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -55,6 +55,14 @@ class AssertEqualsIsDiscouragedRule implements Rule
 			&& ($leftType->isSuperTypeOf($rightType)->yes())
 			&& ($rightType->isSuperTypeOf($leftType)->yes())
 		) {
+			if (strtolower($node->name->name) === 'assertnotequals') {
+				return [
+					RuleErrorBuilder::message(
+						'You should use assertNotSame() instead of assertNotEquals(), because both values are scalars of the same type',
+					)->identifier('phpunit.assertEquals')->build(),
+				];
+			}
+
 			return [
 				RuleErrorBuilder::message(
 					'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type',

--- a/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
+++ b/tests/Rules/PHPUnit/AssertEqualsIsDiscouragedRuleTest.php
@@ -11,25 +11,26 @@ use PHPStan\Testing\RuleTestCase;
 final class AssertEqualsIsDiscouragedRuleTest extends RuleTestCase
 {
 
-	private const ERROR_MESSAGE = 'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type';
+	private const ERROR_MESSAGE_EQUALS = 'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type';
+	private const ERROR_MESSAGE_NOT_EQUALS = 'You should use assertNotSame() instead of assertNotEquals(), because both values are scalars of the same type';
 
 	public function testRule(): void
 	{
 		$this->analyse([__DIR__ . '/data/assert-equals-is-discouraged.php'], [
-			[self::ERROR_MESSAGE, 19],
-			[self::ERROR_MESSAGE, 22],
-			[self::ERROR_MESSAGE, 23],
-			[self::ERROR_MESSAGE, 24],
-			[self::ERROR_MESSAGE, 25],
-			[self::ERROR_MESSAGE, 26],
-			[self::ERROR_MESSAGE, 27],
-			[self::ERROR_MESSAGE, 28],
-			[self::ERROR_MESSAGE, 29],
-			[self::ERROR_MESSAGE, 30],
-			[self::ERROR_MESSAGE, 32],
-			[self::ERROR_MESSAGE, 37],
-			[self::ERROR_MESSAGE, 38],
-			[self::ERROR_MESSAGE, 39],
+			[self::ERROR_MESSAGE_EQUALS, 19],
+			[self::ERROR_MESSAGE_EQUALS, 22],
+			[self::ERROR_MESSAGE_EQUALS, 23],
+			[self::ERROR_MESSAGE_EQUALS, 24],
+			[self::ERROR_MESSAGE_EQUALS, 25],
+			[self::ERROR_MESSAGE_EQUALS, 26],
+			[self::ERROR_MESSAGE_EQUALS, 27],
+			[self::ERROR_MESSAGE_EQUALS, 28],
+			[self::ERROR_MESSAGE_EQUALS, 29],
+			[self::ERROR_MESSAGE_EQUALS, 30],
+			[self::ERROR_MESSAGE_EQUALS, 32],
+			[self::ERROR_MESSAGE_NOT_EQUALS, 37],
+			[self::ERROR_MESSAGE_NOT_EQUALS, 38],
+			[self::ERROR_MESSAGE_NOT_EQUALS, 39],
 		]);
 	}
 


### PR DESCRIPTION
In #219 , "assertNotEquals" was added as discouraged. When there is a usage of "assertNotEquals" though, the error message still references "assertEquals" and "assertSame"