### PR TITLE
move analyse-paths into phpstan.neon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ cs-fix:
 
 .PHONY: phpstan
 phpstan:
-	php vendor/bin/phpstan analyse -c phpstan.neon src tests
+	php vendor/bin/phpstan analyse -c phpstan.neon
 
 .PHONY: phpstan-generate-baseline
 phpstan-generate-baseline:
-	php vendor/bin/phpstan analyse -c phpstan.neon src tests -b phpstan-baseline.neon
+	php vendor/bin/phpstan analyse -c phpstan.neon -b phpstan-baseline.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,10 @@ parameters:
 
 	resultCachePath: tmp/resultCache.php
 
+	paths:
+		- src
+		- tests
+
 	excludePaths:
 		- tests/*/data/*
 	ignoreErrors:


### PR DESCRIPTION
should fix

```
In InitialStaticAnalysisRunFailed.php line 29:
                                                                               
  Project static analysis must be in a passing state before running Infection  
  .                                                                            
  PHPStan reported an exit code of 1.                                          
  Refer to the PHPStan's output below:                                         
  STDERR:                                                                      
  At least one path must be specified to analyse.           
  ```

in https://github.com/phpstan/build-infection/pull/15