### PR TITLE
Assert*Rules: Do cheap checks first

### DIFF
--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -27,6 +27,9 @@ class AssertEqualsIsDiscouragedRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if (!$node instanceof Node\Expr\MethodCall && ! $node instanceof Node\Expr\StaticCall) {
+			return [];
+		}
 		if (count($node->getArgs()) < 2) {
 			return [];
 		}

--- a/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
+++ b/src/Rules/PHPUnit/AssertEqualsIsDiscouragedRule.php
@@ -27,21 +27,21 @@ class AssertEqualsIsDiscouragedRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
+		if (count($node->getArgs()) < 2) {
 			return [];
 		}
-
 		if ($node->isFirstClassCallable()) {
 			return [];
 		}
 
-		if (count($node->getArgs()) < 2) {
-			return [];
-		}
 		if (
 			!$node->name instanceof Node\Identifier
 			|| !in_array(strtolower($node->name->name), ['assertequals', 'assertnotequals'], true)
 		) {
+			return [];
+		}
+
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
 			return [];
 		}
 

--- a/src/Rules/PHPUnit/AssertRuleHelper.php
+++ b/src/Rules/PHPUnit/AssertRuleHelper.php
@@ -11,9 +11,6 @@ use function strtolower;
 class AssertRuleHelper
 {
 
-	/**
-	 * @phpstan-assert-if-true Node\Expr\MethodCall|Node\Expr\StaticCall $node
-	 */
 	public static function isMethodOrStaticCallOnAssert(Node $node, Scope $scope): bool
 	{
 		if ($node instanceof Node\Expr\MethodCall) {

--- a/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
@@ -23,15 +23,10 @@ class AssertSameBooleanExpectedRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
-			return [];
-		}
-
-		if ($node->isFirstClassCallable()) {
-			return [];
-		}
-
 		if (count($node->getArgs()) < 2) {
+			return [];
+		}
+		if ($node->isFirstClassCallable()) {
 			return [];
 		}
 		if (!$node->name instanceof Node\Identifier || $node->name->toLowerString() !== 'assertsame') {
@@ -40,6 +35,10 @@ class AssertSameBooleanExpectedRule implements Rule
 
 		$expectedArgumentValue = $node->getArgs()[0]->value;
 		if (!($expectedArgumentValue instanceof ConstFetch)) {
+			return [];
+		}
+
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
 			return [];
 		}
 

--- a/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameBooleanExpectedRule.php
@@ -23,6 +23,9 @@ class AssertSameBooleanExpectedRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if (!$node instanceof Node\Expr\MethodCall && ! $node instanceof Node\Expr\StaticCall) {
+			return [];
+		}
 		if (count($node->getArgs()) < 2) {
 			return [];
 		}

--- a/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
@@ -23,6 +23,9 @@ class AssertSameNullExpectedRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if (!$node instanceof Node\Expr\MethodCall && ! $node instanceof Node\Expr\StaticCall) {
+			return [];
+		}
 		if (count($node->getArgs()) < 2) {
 			return [];
 		}

--- a/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
+++ b/src/Rules/PHPUnit/AssertSameNullExpectedRule.php
@@ -23,18 +23,17 @@ class AssertSameNullExpectedRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
-			return [];
-		}
-
-		if ($node->isFirstClassCallable()) {
-			return [];
-		}
-
 		if (count($node->getArgs()) < 2) {
 			return [];
 		}
+		if ($node->isFirstClassCallable()) {
+			return [];
+		}
 		if (!$node->name instanceof Node\Identifier || $node->name->toLowerString() !== 'assertsame') {
+			return [];
+		}
+
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
 			return [];
 		}
 

--- a/src/Rules/PHPUnit/AssertSameWithCountRule.php
+++ b/src/Rules/PHPUnit/AssertSameWithCountRule.php
@@ -24,23 +24,21 @@ class AssertSameWithCountRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
-			return [];
-		}
-
-		if ($node->isFirstClassCallable()) {
-			return [];
-		}
-
 		if (count($node->getArgs()) < 2) {
+			return [];
+		}
+		if ($node->isFirstClassCallable()) {
 			return [];
 		}
 		if (!$node->name instanceof Node\Identifier || $node->name->toLowerString() !== 'assertsame') {
 			return [];
 		}
 
-		$right = $node->getArgs()[1]->value;
+		if (!AssertRuleHelper::isMethodOrStaticCallOnAssert($node, $scope)) {
+			return [];
+		}
 
+		$right = $node->getArgs()[1]->value;
 		if (
 			$right instanceof Node\Expr\FuncCall
 			&& $right->name instanceof Node\Name

--- a/src/Rules/PHPUnit/AssertSameWithCountRule.php
+++ b/src/Rules/PHPUnit/AssertSameWithCountRule.php
@@ -24,13 +24,16 @@ class AssertSameWithCountRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if (!$node instanceof Node\Expr\MethodCall && ! $node instanceof Node\Expr\StaticCall) {
+			return [];
+		}
 		if (count($node->getArgs()) < 2) {
 			return [];
 		}
 		if ($node->isFirstClassCallable()) {
 			return [];
 		}
-		if (!$node->name instanceof Node\Identifier || $node->name->toLowerString() !== 'assertsame') {
+		if (!$node->name instanceof Node\Identifier	|| $node->name->toLowerString() !== 'assertsame') {
 			return [];
 		}
 


### PR DESCRIPTION
shuffling the initial if-checks so the cheapest ones get called first.

`AssertRuleHelper::isMethodOrStaticCallOnAssert` internally uses `new ObjectType('PHPUnit\Framework\Assert')` which triggers reflection logic and file parsing

see

<img width="890" height="456" alt="grafik" src="https://github.com/user-attachments/assets/1403f9ff-eb25-4713-8a41-ea13900731f5" />

---

refs https://github.com/phpstan/build-infection/issues/16
