### PR TITLE
PHPUnit 9.x/10.x does not at all support named arguments from data-providers

### DIFF
--- a/src/Rules/PHPUnit/DataProviderDataRule.php
+++ b/src/Rules/PHPUnit/DataProviderDataRule.php
@@ -23,13 +23,17 @@ class DataProviderDataRule implements Rule
 
 	private DataProviderHelper $dataProviderHelper;
 
+	private PHPUnitVersion $PHPUnitVersion;
+
 	public function __construct(
 		TestMethodsHelper $testMethodsHelper,
-		DataProviderHelper $dataProviderHelper
+		DataProviderHelper $dataProviderHelper,
+		PHPUnitVersion $PHPUnitVersion
 	)
 	{
 		$this->testMethodsHelper = $testMethodsHelper;
 		$this->dataProviderHelper = $dataProviderHelper;
+		$this->PHPUnitVersion = $PHPUnitVersion;
 	}
 
 	public function getNodeType(): string
@@ -153,11 +157,10 @@ class DataProviderDataRule implements Rule
 				return null;
 			}
 
-			if (count($key) === 0) {
+			if (count($key) === 0 || !$this->PHPUnitVersion->supportsNamedArgumentsInDataProvider()->yes()) {
 				$arg = new Node\Arg(new TypeExpr($valueType));
 				$args[] = $arg;
 				continue;
-
 			}
 
 			$arg = new Node\Arg(

--- a/src/Rules/PHPUnit/PHPUnitVersion.php
+++ b/src/Rules/PHPUnit/PHPUnitVersion.php
@@ -38,4 +38,12 @@ class PHPUnitVersion
 		return TrinaryLogic::createFromBoolean($this->majorVersion >= 10);
 	}
 
+	public function supportsNamedArgumentsInDataProvider(): TrinaryLogic
+	{
+		if ($this->majorVersion === null) {
+			return TrinaryLogic::createMaybe();
+		}
+		return TrinaryLogic::createFromBoolean($this->majorVersion >= 11);
+	}
+
 }

--- a/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
@@ -308,11 +308,14 @@ class DataProviderDataRuleTest extends RuleTestCase
 
 	static public function provideNamedArgumentPHPUnitVersions(): iterable
 	{
-		return [
-			[null],
-			[10],
-			[11],
-		];
+		yield [null]; // unknown phpunit version
+
+		if (PHP_VERSION_ID >= 80100) {
+			yield [10]; // PHPUnit 10.x requires PHP 8.1+
+		}
+		if (PHP_VERSION_ID >= 80200) {
+			yield [11]; // PHPUnit 11.x requires PHP 8.2+
+		}
 	}
 
 	/**
@@ -324,10 +327,6 @@ class DataProviderDataRuleTest extends RuleTestCase
 		$this->phpunitVersion = $phpunitVersion;
 
 		if ($phpunitVersion >= 11) {
-			if (PHP_VERSION_ID < 80000) {
-				self::markTestSkipped('PHPUnit11 requires PHP 8.0+');
-			}
-
 			$errors = [];
 		} else {
 			$errors = [

--- a/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
@@ -179,9 +179,9 @@ class DataProviderDataRuleTest extends RuleTestCase
 
 
 	/**
-	 * @dataProvider provideNamedArgumentVersions
+	 * @dataProvider provideNamedArgumentPHPUnitVersions
 	 */
-	#[DataProvider('provideNamedArgumentVersions')]
+	#[DataProvider('provideNamedArgumentPHPUnitVersions')]
 	public function testRulePhp8(?int $phpunitVersion): void
 	{
 		if (PHP_VERSION_ID < 80000) {
@@ -306,7 +306,7 @@ class DataProviderDataRuleTest extends RuleTestCase
 		]);
 	}
 
-	static public function provideNamedArgumentVersions(): iterable
+	static public function provideNamedArgumentPHPUnitVersions(): iterable
 	{
 		return [
 			[null],
@@ -316,9 +316,9 @@ class DataProviderDataRuleTest extends RuleTestCase
 	}
 
 	/**
-	 * @dataProvider provideNamedArgumentVersions
+	 * @dataProvider provideNamedArgumentPHPUnitVersions
 	 */
-	#[DataProvider('provideNamedArgumentVersions')]
+	#[DataProvider('provideNamedArgumentPHPUnitVersions')]
 	public function testNamedArgumentsInDataProviders(?int $phpunitVersion): void
 	{
 		$this->phpunitVersion = $phpunitVersion;

--- a/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
@@ -179,7 +179,7 @@ class DataProviderDataRuleTest extends RuleTestCase
 	public function testRulePhp8(): void
 	{
 		if (PHP_VERSION_ID < 80000) {
-			self::markTestSkipped('PHPUnit11 requires PHP 8.0.');
+			self::markTestSkipped();
 		}
 
 		$this->phpunitVersion = 10;

--- a/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
@@ -324,9 +324,11 @@ class DataProviderDataRuleTest extends RuleTestCase
 		$this->phpunitVersion = $phpunitVersion;
 
 		if ($phpunitVersion >= 11) {
+			if (PHP_VERSION_ID < 80000) {
+				self::markTestSkipped('PHPUnit11 requires PHP 8.0+');
+			}
+
 			$errors = [];
-			$this->analyse([__DIR__ . '/data/data-provider-named-args.php'], [
-			]);
 		} else {
 			$errors = [
 				[

--- a/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\Methods\CallMethodsRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
+use PHPUnit\Framework\Attributes\DataProvider;
 use const PHP_VERSION_ID;
 
 /**
@@ -15,7 +16,7 @@ use const PHP_VERSION_ID;
  */
 class DataProviderDataRuleTest extends RuleTestCase
 {
-	private int $phpunitVersion;
+	private ?int $phpunitVersion;
 
 	protected function getRule(): Rule
 	{
@@ -272,36 +273,44 @@ class DataProviderDataRuleTest extends RuleTestCase
 		]);
 	}
 
-	public function testNamedArgumentsInDataProviders(): void
+	static public function provideNamedArgumentVersions(): iterable
 	{
-		$this->phpunitVersion = 10;
-
-		$this->analyse([__DIR__ . '/data/data-provider-named-args.php'], [
-			[
-				'Parameter #1 $int of method DataProviderNamedArgs\FooTest::testFoo() expects int, string given.',
-				26
-			],
-			[
-				'Parameter #2 $string of method DataProviderNamedArgs\FooTest::testFoo() expects string, int given.',
-				26
-			],
-		]);
+		return [
+			[null],
+			[10],
+			[11],
+		];
 	}
 
-	public function testNamedArgumentsInDataProvidersPhpUnit11OrNewer(): void
+	/**
+	 * @dataProvider provideNamedArgumentVersions
+	 */
+	#[DataProvider('provideNamedArgumentVersions')]
+	public function testNamedArgumentsInDataProviders(?int $phpunitVersion): void
 	{
-		if (PHP_VERSION_ID < 80000) {
-			self::markTestSkipped('PHPUnit11 requires PHP 8.0.');
+		$this->phpunitVersion = $phpunitVersion;
+
+		if ($phpunitVersion >= 11) {
+			$errors = [];
+			$this->analyse([__DIR__ . '/data/data-provider-named-args.php'], [
+			]);
+		} else {
+			$errors = [
+				[
+					'Parameter #1 $int of method DataProviderNamedArgs\FooTest::testFoo() expects int, string given.',
+					26
+				],
+				[
+					'Parameter #2 $string of method DataProviderNamedArgs\FooTest::testFoo() expects string, int given.',
+					26
+				],
+			];
 		}
 
-		$this->phpunitVersion = 11;
-
-		$this->analyse([__DIR__ . '/data/data-provider-named-args.php'], [
-		]);
+		$this->analyse([__DIR__ . '/data/data-provider-named-args.php'], $errors);
 	}
 
-
-		/**
+	/**
 	 * @return string[]
 	 */
 	public static function getAdditionalConfigFiles(): array

--- a/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\Methods\CallMethodsRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<CompositeRule>
@@ -19,21 +20,22 @@ class DataProviderDataRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = $this->createReflectionProvider();
+		$phpunitVersion = new PHPUnitVersion($this->phpunitVersion);
 
 		/** @var list<Rule<Node>> $rules */
 		$rules = [
 			new DataProviderDataRule(
 				new TestMethodsHelper(
 					self::getContainer()->getByType(FileTypeMapper::class),
-					new PHPUnitVersion($this->phpunitVersion)
+					$phpunitVersion
 				),
 				new DataProviderHelper(
 					$reflectionProvider,
 					self::getContainer()->getByType(FileTypeMapper::class),
 					self::getContainer()->getService('defaultAnalysisParser'),
-					new PHPUnitVersion($this->phpunitVersion)
+					$phpunitVersion
 				),
-
+				$phpunitVersion,
 			),
 			self::getContainer()->getByType(CallMethodsRule::class) /** @phpstan-ignore phpstanApi.classConstant */
 		];
@@ -176,30 +178,26 @@ class DataProviderDataRuleTest extends RuleTestCase
 	public function testRulePhp8(): void
 	{
 		if (PHP_VERSION_ID < 80000) {
-			self::markTestSkipped();
+			self::markTestSkipped('PHPUnit11 requires PHP 8.0.');
 		}
 
 		$this->phpunitVersion = 10;
 
 		$this->analyse([__DIR__ . '/data/data-provider-data-named.php'], [
 			[
-				'Parameter $input of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, int given.',
+				'Parameter #1 $expectedResult of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, int given.',
 				44
 			],
 			[
-				'Parameter $input of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, false given.',
+				'Parameter #1 $expectedResult of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, false given.',
 				44
 			],
 			[
-				'Unknown parameter $wrong in call to method DataProviderDataTestPhp8\TestWrongOffsetNameArrayShapeIterable::testBar().',
+				'Parameter #1 $si of method DataProviderDataTestPhp8\TestWrongOffsetNameArrayShapeIterable::testBar() expects int, string given.',
 				58
 			],
 			[
-				'Missing parameter $si (int) in call to method DataProviderDataTestPhp8\TestWrongOffsetNameArrayShapeIterable::testBar().',
-				58
-			],
-			[
-				'Parameter $si of method DataProviderDataTestPhp8\TestWrongTypeInArrayShapeIterable::testBar() expects int, string given.',
+				'Parameter #1 $si of method DataProviderDataTestPhp8\TestWrongTypeInArrayShapeIterable::testBar() expects int, string given.',
 				79
 			],
 		]);
@@ -274,7 +272,36 @@ class DataProviderDataRuleTest extends RuleTestCase
 		]);
 	}
 
-	/**
+	public function testNamedArgumentsInDataProviders(): void
+	{
+		$this->phpunitVersion = 10;
+
+		$this->analyse([__DIR__ . '/data/data-provider-named-args.php'], [
+			[
+				'Parameter #1 $int of method DataProviderNamedArgs\FooTest::testFoo() expects int, string given.',
+				26
+			],
+			[
+				'Parameter #2 $string of method DataProviderNamedArgs\FooTest::testFoo() expects string, int given.',
+				26
+			],
+		]);
+	}
+
+	public function testNamedArgumentsInDataProvidersPhpUnit11OrNewer(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			self::markTestSkipped('PHPUnit11 requires PHP 8.0.');
+		}
+
+		$this->phpunitVersion = 11;
+
+		$this->analyse([__DIR__ . '/data/data-provider-named-args.php'], [
+		]);
+	}
+
+
+		/**
 	 * @return string[]
 	 */
 	public static function getAdditionalConfigFiles(): array

--- a/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
+++ b/tests/Rules/PHPUnit/DataProviderDataRuleTest.php
@@ -9,6 +9,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use const PHP_VERSION_ID;
 
 /**
@@ -176,32 +177,64 @@ class DataProviderDataRuleTest extends RuleTestCase
 		]);
 	}
 
-	public function testRulePhp8(): void
+
+	/**
+	 * @dataProvider provideNamedArgumentVersions
+	 */
+	#[DataProvider('provideNamedArgumentVersions')]
+	public function testRulePhp8(?int $phpunitVersion): void
 	{
 		if (PHP_VERSION_ID < 80000) {
 			self::markTestSkipped();
 		}
 
-		$this->phpunitVersion = 10;
+		$this->phpunitVersion = $phpunitVersion;
 
-		$this->analyse([__DIR__ . '/data/data-provider-data-named.php'], [
-			[
-				'Parameter #1 $expectedResult of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, int given.',
-				44
-			],
-			[
-				'Parameter #1 $expectedResult of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, false given.',
-				44
-			],
-			[
-				'Parameter #1 $si of method DataProviderDataTestPhp8\TestWrongOffsetNameArrayShapeIterable::testBar() expects int, string given.',
-				58
-			],
-			[
-				'Parameter #1 $si of method DataProviderDataTestPhp8\TestWrongTypeInArrayShapeIterable::testBar() expects int, string given.',
-				79
-			],
-		]);
+		if ($phpunitVersion >= 11) {
+			$errors = [
+				[
+					'Parameter $input of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, int given.',
+					44
+				],
+				[
+					'Parameter $input of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, false given.',
+					44
+				],
+				[
+					'Unknown parameter $wrong in call to method DataProviderDataTestPhp8\TestWrongOffsetNameArrayShapeIterable::testBar().',
+					58
+				],
+				[
+					'Missing parameter $si (int) in call to method DataProviderDataTestPhp8\TestWrongOffsetNameArrayShapeIterable::testBar().',
+					58
+				],
+				[
+					'Parameter $si of method DataProviderDataTestPhp8\TestWrongTypeInArrayShapeIterable::testBar() expects int, string given.',
+					79
+				],
+			];
+		} else {
+			$errors = [
+				[
+					'Parameter #1 $expectedResult of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, int given.',
+					44
+				],
+				[
+					'Parameter #1 $expectedResult of method DataProviderDataTestPhp8\NamedArgsInProvider::testFoo() expects string, false given.',
+					44
+				],
+				[
+					'Parameter #1 $si of method DataProviderDataTestPhp8\TestWrongOffsetNameArrayShapeIterable::testBar() expects int, string given.',
+					58
+				],
+				[
+					'Parameter #1 $si of method DataProviderDataTestPhp8\TestWrongTypeInArrayShapeIterable::testBar() expects int, string given.',
+					79
+				],
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/data-provider-data-named.php'], $errors);
 	}
 
 

--- a/tests/Rules/PHPUnit/data/data-provider-named-args.php
+++ b/tests/Rules/PHPUnit/data/data-provider-named-args.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DataProviderNamedArgs;
+
+class FooTest extends \PHPUnit\Framework\TestCase
+{
+
+	/**
+	 * @dataProvider dataProvider
+	 */
+	public function testFoo(
+		int    $int,
+		string $string
+	): void
+	{
+		$this->assertTrue(true);
+	}
+
+	public static function dataProvider(): iterable
+	{
+		yield 'even' => [
+			'int' => 50,
+			'string' => 'abc',
+		];
+
+		yield 'odd' => [
+			'string' => 'def',
+			'int' => 51,
+		];
+	}
+}
+


### PR DESCRIPTION
prevents phpstan-src errors we currently see on PHP 7.x:

```
------ ------------------------------------------------------------------ 
  Line   tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php  
 ------ ------------------------------------------------------------------ 
  44     Named arguments are supported only on PHP 8.0 and later.          
  57     Named arguments are supported only on PHP 8.0 and later.          
  76     Named arguments are supported only on PHP 8.0 and later.          
  95     Named arguments are supported only on PHP 8.0 and later.          
  124    Named arguments are supported only on PHP 8.0 and later.          
  144    Named arguments are supported only on PHP 8.0 and later.          
  180    Named arguments are supported only on PHP 8.0 and later.          
  199    Named arguments are supported only on PHP 8.0 and later.          
  220    Named arguments are supported only on PHP 8.0 and later.          
  241    Named arguments are supported only on PHP 8.0 and later.          
 ------ ------------------------------------------------------------------ 
 ```

refs https://github.com/phpstan/phpstan-src/pull/4490#issuecomment-3455197803