### PR TITLE
Remove checkDataProviderData and introduce reportMissingDataProviderReturnType

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -1,7 +1,7 @@
 parameters:
 	phpunit:
 		convertUnionToIntersectionType: true
-		checkDataProviderData: %featureToggles.bleedingEdge%
+		ignoreMissingDataProviderReturnType: true
 	additionalConstructors:
 		- PHPUnit\Framework\TestCase::setUp
 	earlyTerminatingMethodCalls:
@@ -24,8 +24,8 @@ parameters:
 
 parametersSchema:
 	phpunit: structure([
-		convertUnionToIntersectionType: bool()
-		checkDataProviderData: bool(),
+		convertUnionToIntersectionType: bool(),
+		ignoreMissingDataProviderReturnType: bool(),
 	])
 
 services:
@@ -76,4 +76,4 @@ conditionalTags:
 	PHPStan\PhpDoc\PHPUnit\MockObjectTypeNodeResolverExtension:
 		phpstan.phpDoc.typeNodeResolverExtension: %phpunit.convertUnionToIntersectionType%
 	PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension:
-		phpstan.ignoreErrorExtension: %phpunit.checkDataProviderData%
+		phpstan.ignoreErrorExtension: [%featureToggles.bleedingEdge%, %phpunit.ignoreMissingDataProviderReturnType%]

--- a/extension.neon
+++ b/extension.neon
@@ -1,7 +1,7 @@
 parameters:
 	phpunit:
 		convertUnionToIntersectionType: true
-		ignoreMissingDataProviderReturnType: true
+		reportMissingDataProviderReturnType: false
 	additionalConstructors:
 		- PHPUnit\Framework\TestCase::setUp
 	earlyTerminatingMethodCalls:
@@ -25,7 +25,7 @@ parameters:
 parametersSchema:
 	phpunit: structure([
 		convertUnionToIntersectionType: bool(),
-		ignoreMissingDataProviderReturnType: bool(),
+		reportMissingDataProviderReturnType: bool(),
 	])
 
 services:
@@ -76,4 +76,4 @@ conditionalTags:
 	PHPStan\PhpDoc\PHPUnit\MockObjectTypeNodeResolverExtension:
 		phpstan.phpDoc.typeNodeResolverExtension: %phpunit.convertUnionToIntersectionType%
 	PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension:
-		phpstan.ignoreErrorExtension: [%featureToggles.bleedingEdge%, %phpunit.ignoreMissingDataProviderReturnType%]
+		phpstan.ignoreErrorExtension: [%featureToggles.bleedingEdge%, not(%phpunit.reportMissingDataProviderReturnType%)]

--- a/rules.neon
+++ b/rules.neon
@@ -14,7 +14,7 @@ conditionalTags:
 		phpstan.rules.rule: [%strictRulesInstalled%, %featureToggles.bleedingEdge%]
 
 	PHPStan\Rules\PHPUnit\DataProviderDataRule:
-		phpstan.rules.rule: %phpunit.checkDataProviderData%
+		phpstan.rules.rule: %featureToggles.bleedingEdge%
 
 services:
 	-

--- a/tests/Type/PHPUnit/data/data-provider-iterable-value.neon
+++ b/tests/Type/PHPUnit/data/data-provider-iterable-value.neon
@@ -1,6 +1,6 @@
 parameters:
-	phpunit:
-		checkDataProviderData: true
+	featureToggles:
+		bleedingEdge: true
 
 includes:
 	- ../../../../extension.neon


### PR DESCRIPTION
Cf https://github.com/phpstan/phpstan-phpunit/pull/246#issuecomment-3476171114

I did `ignoreMissingDataProviderReturnType` rather than `reportMissingDataProviderReturnType` because it allows to write
```
	PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension:
		phpstan.ignoreErrorExtension: [%featureToggles.bleedingEdge%, %phpunit.ignoreMissingDataProviderReturnType%]
```
and I dunno how a syntax
```
	PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension:
		phpstan.ignoreErrorExtension: [%featureToggles.bleedingEdge%, NOT(%phpunit.reportMissingDataProviderReturnType%)]
```
would exists