### PR TITLE
Sanity check `#[RequiresPhp]` value and range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"phar-io/version": "^3.2",
-		"phpstan/phpstan": "^2.1.48"
+		"phpstan/phpstan": "^2.2.3"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
 	"keywords": ["static analysis"],
 	"require": {
 		"php": "^7.4 || ^8.0",
+		"phar-io/version": "^3.2",
 		"phpstan/phpstan": "^2.1.48"
 	},
 	"conflict": {

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -2,11 +2,8 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
-use Composer\Semver\Constraint\ConstraintInterface;
-use Composer\Semver\VersionParser;
 use PharIo\Version\UnsupportedVersionConstraintException;
 use PharIo\Version\Version;
-use PharIo\Version\VersionConstraint;
 use PharIo\Version\VersionConstraintParser;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
@@ -15,20 +12,20 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPUnit\Framework\TestCase;
-use UnexpectedValueException;
 use function count;
 use function is_numeric;
 use function method_exists;
 use function preg_match;
 use function sprintf;
+use function version_compare;
 
 /**
  * @implements Rule<InClassMethodNode>
  */
 class AttributeRequiresPhpVersionRule implements Rule
 {
-	private const VERSION_COMPARISON = "/(?P<operator>!=|<|<=|<>|=|==|>|>=)?\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m";
 
+	private const VERSION_COMPARISON = "/(?P<operator>!=|<|<=|<>|=|==|>|>=)?\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m";
 
 	private Version $phpstanPhpVersion;
 
@@ -90,19 +87,19 @@ class AttributeRequiresPhpVersionRule implements Rule
 						continue;
 					}
 				} catch (UnsupportedVersionConstraintException $e) {
-					if (preg_match(self::VERSION_COMPARISON, $args[0], $matches) > 0) {
-						$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
-
-						if (version_compare($this->phpstanPhpVersion->getVersionString(), $matches['version'], $operator)) {
-							continue;
-						}
-					} else {
+					if (preg_match(self::VERSION_COMPARISON, $args[0], $matches) <= 0) {
 						$errors[] = RuleErrorBuilder::message(
 							sprintf($e->getMessage()),
 						)
 							->identifier('phpunit.attributeRequiresPhpVersion')
 							->build();
 
+						continue;
+					}
+
+					$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
+
+					if (version_compare($this->phpstanPhpVersion->getVersionString(), $matches['version'], $operator)) {
 						continue;
 					}
 				}

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -74,33 +74,27 @@ class AttributeRequiresPhpVersionRule implements Rule
 			}
 
 			if (
-				is_numeric($args[0])
+				!is_numeric($args[0])
 			) {
-				if ($this->PHPUnitVersion->requiresPhpversionAttributeWithOperator()->yes()) {
+
+				try {
+					$testPhpVersionConstraint = $parser->parseConstraints($args[0]);
+				} catch (UnexpectedValueException $e) {
 					$errors[] = RuleErrorBuilder::message(
-						sprintf('Version requirement is missing operator.'),
+						sprintf($e->getMessage()),
 					)
 						->identifier('phpunit.attributeRequiresPhpVersion')
 						->build();
-				} elseif (
-					$this->deprecationRulesInstalled
-					&& $this->PHPUnitVersion->deprecatesPhpversionAttributeWithoutOperator()->yes()
-				) {
-					$errors[] = RuleErrorBuilder::message(
-						sprintf('Version requirement without operator is deprecated.'),
-					)
-						->identifier('phpunit.attributeRequiresPhpVersion')
-						->build();
+
+					continue;
 				}
 
-				continue;
-			}
+				if ($this->phpstanVersionConstraint->matches($testPhpVersionConstraint)) {
+					continue;
+				}
 
-			try {
-				$testPhpVersionConstraint = $parser->parseConstraints($args[0]);
-			} catch (UnexpectedValueException $e) {
 				$errors[] = RuleErrorBuilder::message(
-					sprintf($e->getMessage()),
+					sprintf('Version requirement will always evaluate to false.'),
 				)
 					->identifier('phpunit.attributeRequiresPhpVersion')
 					->build();
@@ -108,15 +102,22 @@ class AttributeRequiresPhpVersionRule implements Rule
 				continue;
 			}
 
-			if ($this->phpstanVersionConstraint->matches($testPhpVersionConstraint)) {
-				continue;
+			if ($this->PHPUnitVersion->requiresPhpversionAttributeWithOperator()->yes()) {
+				$errors[] = RuleErrorBuilder::message(
+					sprintf('Version requirement is missing operator.'),
+				)
+					->identifier('phpunit.attributeRequiresPhpVersion')
+					->build();
+			} elseif (
+				$this->deprecationRulesInstalled
+				&& $this->PHPUnitVersion->deprecatesPhpversionAttributeWithoutOperator()->yes()
+			) {
+				$errors[] = RuleErrorBuilder::message(
+					sprintf('Version requirement without operator is deprecated.'),
+				)
+					->identifier('phpunit.attributeRequiresPhpVersion')
+					->build();
 			}
-
-			$errors[] = RuleErrorBuilder::message(
-				sprintf('Version requirement will always evaluate to false.'),
-			)
-				->identifier('phpunit.attributeRequiresPhpVersion')
-				->build();
 		}
 
 		return $errors;

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -8,6 +8,7 @@ use PharIo\Version\VersionConstraintParser;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
+use PHPStan\Php\PhpMinorVersionIterator;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -69,15 +70,9 @@ class AttributeRequiresPhpVersionRule implements Rule
 			return [];
 		}
 
-		$scopePhpVersion = $scope->getPhpVersion()->getType();
-		if ($scopePhpVersion instanceof ConstantIntegerType) {
-			$v = new PhpVersion($scopePhpVersion->getValue());
-			$phpstanPharIoVersion = new Version($v->getVersionString());
-		} elseif ($scopePhpVersion instanceof IntegerRangeType && $scopePhpVersion->getMin() !== null) {
-			$v = new PhpVersion($scopePhpVersion->getMin());
-			$phpstanPharIoVersion = new Version($v->getVersionString());
-		} else {
-			$phpstanPharIoVersion = new Version($this->fallbackPhpVersion->getVersionString());
+		$phpstanPharIoVersions = $this->getAnalyzedPhpVersions($scope);
+		if ($phpstanPharIoVersions === []) {
+			return [];
 		}
 
 		$errors = [];
@@ -99,8 +94,11 @@ class AttributeRequiresPhpVersionRule implements Rule
 					// check composer like version constraints, e.g. ^1  or ~2
 					$testPhpVersionConstraint = $parser->parse($versionRequirement);
 
-					if ($testPhpVersionConstraint->complies($phpstanPharIoVersion)) {
-						continue;
+					foreach ($phpstanPharIoVersions as $pharIoVersion) {
+						if ($testPhpVersionConstraint->complies($pharIoVersion)) {
+							// one of the versions within range matched, check next attribute
+							continue 2;
+						}
 					}
 				} catch (UnsupportedVersionConstraintException $e) {
 					// test php-src builtin operators as in version_compare()
@@ -116,8 +114,10 @@ class AttributeRequiresPhpVersionRule implements Rule
 
 					$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
 
-					if (version_compare($phpstanPharIoVersion->getVersionString(), $matches['version'], $operator)) {
-						continue;
+					foreach ($phpstanPharIoVersions as $pharIoVersion) {
+						if (version_compare($pharIoVersion->getVersionString(), $matches['version'], $operator)) {
+							continue 2;
+						}
 					}
 				}
 
@@ -149,6 +149,34 @@ class AttributeRequiresPhpVersionRule implements Rule
 		}
 
 		return $errors;
+	}
+
+	/**
+	 * @return Version[]
+	 */
+	private function getAnalyzedPhpVersions(Scope $scope): array
+	{
+		$scopePhpVersion = $scope->getPhpVersion()->getType();
+		if ($scopePhpVersion instanceof ConstantIntegerType) {
+			$v = new PhpVersion($scopePhpVersion->getValue());
+			return [new Version($v->getVersionString())];
+		} elseif ($scopePhpVersion instanceof IntegerRangeType) {
+			if ($scopePhpVersion->getMin() === null || $scopePhpVersion->getMax() === null) {
+				return [];
+			}
+
+			$versions = [];
+			$minorVersionIterator = new PhpMinorVersionIterator(
+				new PhpVersion($scopePhpVersion->getMin()),
+				new PhpVersion($scopePhpVersion->getMax()),
+			);
+			foreach ($minorVersionIterator as $phpstanVersion) {
+				$versions[] = new Version($phpstanVersion->getVersionString());
+			}
+			return $versions;
+		}
+
+		return [new Version($this->fallbackPhpVersion->getVersionString())];
 	}
 
 }

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -8,9 +8,12 @@ use PharIo\Version\VersionConstraintParser;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
+use PHPStan\Php\ComposerPhpVersionParser;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\IntegerRangeType;
 use PHPUnit\Framework\TestCase;
 use function count;
 use function is_numeric;
@@ -26,11 +29,11 @@ class AttributeRequiresPhpVersionRule implements Rule
 
 	private const VERSION_COMPARISON = "/(?P<operator>!=|<|<=|<>|=|==|>|>=)?\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m";
 
-	private Version $phpstanPhpVersion;
-
 	private PHPUnitVersion $PHPUnitVersion;
 
 	private TestMethodsHelper $testMethodsHelper;
+
+	private PhpVersion $fallbackPhpVersion;
 
 	/**
 	 * When phpstan-deprecation-rules is installed, it reports deprecated usages.
@@ -47,8 +50,7 @@ class AttributeRequiresPhpVersionRule implements Rule
 		$this->PHPUnitVersion = $PHPUnitVersion;
 		$this->testMethodsHelper = $testMethodsHelper;
 		$this->deprecationRulesInstalled = $deprecationRulesInstalled;
-
-		$this->phpstanPhpVersion = new Version($phpVersion->getVersionString());
+		$this->fallbackPhpVersion = $phpVersion;
 	}
 
 	public function getNodeType(): string
@@ -66,6 +68,17 @@ class AttributeRequiresPhpVersionRule implements Rule
 		$reflectionMethod = $this->testMethodsHelper->getTestMethodReflection($classReflection, $node->getMethodReflection(), $scope);
 		if ($reflectionMethod === null) {
 			return [];
+		}
+
+		$phpversionType = $scope->getPhpVersion()->getType();
+		if ($phpversionType instanceof ConstantIntegerType) {
+			$v = new PhpVersion($phpversionType->getValue());
+			$phpstanPharIoVersion = new Version($v->getVersionString());
+		} elseif ($phpversionType instanceof IntegerRangeType && $phpversionType->getMin() !== null) {
+			$v = new PhpVersion($phpversionType->getMin());
+			$phpstanPharIoVersion = new Version($v->getVersionString());
+		} else {
+			$phpstanPharIoVersion = new Version($this->fallbackPhpVersion->getVersionString());
 		}
 
 		$errors = [];
@@ -87,7 +100,7 @@ class AttributeRequiresPhpVersionRule implements Rule
 					// check composer like version constraints, e.g. ^1  or ~2
 					$testPhpVersionConstraint = $parser->parse($versionRequirement);
 
-					if ($testPhpVersionConstraint->complies($this->phpstanPhpVersion)) {
+					if ($testPhpVersionConstraint->complies($phpstanPharIoVersion)) {
 						continue;
 					}
 				} catch (UnsupportedVersionConstraintException $e) {
@@ -104,7 +117,7 @@ class AttributeRequiresPhpVersionRule implements Rule
 
 					$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
 
-					if (version_compare($this->phpstanPhpVersion->getVersionString(), $matches['version'], $operator)) {
+					if (version_compare($phpstanPharIoVersion->getVersionString(), $matches['version'], $operator)) {
 						continue;
 					}
 				}

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -81,12 +81,14 @@ class AttributeRequiresPhpVersionRule implements Rule
 				!is_numeric($args[0])
 			) {
 				try {
+					// check composer like version constraints, e.g. ^1  or ~2
 					$testPhpVersionConstraint = $parser->parse($args[0]);
 
 					if ($testPhpVersionConstraint->complies($this->phpstanPhpVersion)) {
 						continue;
 					}
 				} catch (UnsupportedVersionConstraintException $e) {
+					// test php-src builtin operators as in version_compare()
 					if (preg_match(self::VERSION_COMPARISON, $args[0], $matches) <= 0) {
 						$errors[] = RuleErrorBuilder::message(
 							sprintf($e->getMessage()),

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -76,6 +76,9 @@ class AttributeRequiresPhpVersionRule implements Rule
 				continue;
 			}
 
+			// the following block is mimicing PHPUnit version parsing
+			// see https://github.com/sebastianbergmann/phpunit/blob/43c2cd7b96ee1e800b35e4df23b419a88b53111d/src/Metadata/Version/Requirement.php
+
 			$versionRequirement = $args[0];
 			if (
 				!is_numeric($versionRequirement)

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -69,12 +69,12 @@ class AttributeRequiresPhpVersionRule implements Rule
 			return [];
 		}
 
-		$phpversionType = $scope->getPhpVersion()->getType();
-		if ($phpversionType instanceof ConstantIntegerType) {
-			$v = new PhpVersion($phpversionType->getValue());
+		$scopePhpVersion = $scope->getPhpVersion()->getType();
+		if ($scopePhpVersion instanceof ConstantIntegerType) {
+			$v = new PhpVersion($scopePhpVersion->getValue());
 			$phpstanPharIoVersion = new Version($v->getVersionString());
-		} elseif ($phpversionType instanceof IntegerRangeType && $phpversionType->getMin() !== null) {
-			$v = new PhpVersion($phpversionType->getMin());
+		} elseif ($scopePhpVersion instanceof IntegerRangeType && $scopePhpVersion->getMin() !== null) {
+			$v = new PhpVersion($scopePhpVersion->getMin());
 			$phpstanPharIoVersion = new Version($v->getVersionString());
 		} else {
 			$phpstanPharIoVersion = new Version($this->fallbackPhpVersion->getVersionString());

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -14,7 +14,6 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPUnit\Framework\TestCase;
 use function count;
 use function is_numeric;
-use function method_exists;
 use function preg_match;
 use function sprintf;
 use function version_compare;

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -116,6 +116,7 @@ class AttributeRequiresPhpVersionRule implements Rule
 
 					foreach ($phpstanPharIoVersions as $pharIoVersion) {
 						if (version_compare($pharIoVersion->getVersionString(), $matches['version'], $operator)) {
+							// one of the versions within range matched, check next attribute
 							continue 2;
 						}
 					}

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -8,7 +8,6 @@ use PharIo\Version\VersionConstraintParser;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
-use PHPStan\Php\ComposerPhpVersionParser;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -4,6 +4,10 @@ namespace PHPStan\Rules\PHPUnit;
 
 use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Semver\VersionParser;
+use PharIo\Version\UnsupportedVersionConstraintException;
+use PharIo\Version\Version;
+use PharIo\Version\VersionConstraint;
+use PharIo\Version\VersionConstraintParser;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
@@ -14,6 +18,8 @@ use PHPUnit\Framework\TestCase;
 use UnexpectedValueException;
 use function count;
 use function is_numeric;
+use function method_exists;
+use function preg_match;
 use function sprintf;
 
 /**
@@ -21,8 +27,10 @@ use function sprintf;
  */
 class AttributeRequiresPhpVersionRule implements Rule
 {
+	private const VERSION_COMPARISON = "/(?P<operator>!=|<|<=|<>|=|==|>|>=)?\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m";
 
-	private ConstraintInterface $phpstanVersionConstraint;
+
+	private Version $phpstanPhpVersion;
 
 	private PHPUnitVersion $PHPUnitVersion;
 
@@ -44,8 +52,7 @@ class AttributeRequiresPhpVersionRule implements Rule
 		$this->testMethodsHelper = $testMethodsHelper;
 		$this->deprecationRulesInstalled = $deprecationRulesInstalled;
 
-		$parser = new VersionParser();
-		$this->phpstanVersionConstraint = $parser->parseConstraints($phpVersion->getVersionString());
+		$this->phpstanPhpVersion = new Version($phpVersion->getVersionString());
 	}
 
 	public function getNodeType(): string
@@ -66,7 +73,7 @@ class AttributeRequiresPhpVersionRule implements Rule
 		}
 
 		$errors = [];
-		$parser = new VersionParser();
+		$parser = new VersionConstraintParser();
 		foreach ($reflectionMethod->getAttributesByName('PHPUnit\Framework\Attributes\RequiresPhp') as $attr) {
 			$args = $attr->getArguments();
 			if (count($args) !== 1) {
@@ -76,21 +83,28 @@ class AttributeRequiresPhpVersionRule implements Rule
 			if (
 				!is_numeric($args[0])
 			) {
-
 				try {
-					$testPhpVersionConstraint = $parser->parseConstraints($args[0]);
-				} catch (UnexpectedValueException $e) {
-					$errors[] = RuleErrorBuilder::message(
-						sprintf($e->getMessage()),
-					)
-						->identifier('phpunit.attributeRequiresPhpVersion')
-						->build();
+					$testPhpVersionConstraint = $parser->parse($args[0]);
 
-					continue;
-				}
+					if ($testPhpVersionConstraint->complies($this->phpstanPhpVersion)) {
+						continue;
+					}
+				} catch (UnsupportedVersionConstraintException $e) {
+					if (preg_match(self::VERSION_COMPARISON, $args[0], $matches) > 0) {
+						$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
 
-				if ($this->phpstanVersionConstraint->matches($testPhpVersionConstraint)) {
-					continue;
+						if (version_compare($this->phpstanPhpVersion->getVersionString(), $matches['version'], $operator)) {
+							continue;
+						}
+					} else {
+						$errors[] = RuleErrorBuilder::message(
+							sprintf($e->getMessage()),
+						)
+							->identifier('phpunit.attributeRequiresPhpVersion')
+							->build();
+
+						continue;
+					}
 				}
 
 				$errors[] = RuleErrorBuilder::message(

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -77,19 +77,20 @@ class AttributeRequiresPhpVersionRule implements Rule
 				continue;
 			}
 
+			$versionRequirement = $args[0];
 			if (
-				!is_numeric($args[0])
+				!is_numeric($versionRequirement)
 			) {
 				try {
 					// check composer like version constraints, e.g. ^1  or ~2
-					$testPhpVersionConstraint = $parser->parse($args[0]);
+					$testPhpVersionConstraint = $parser->parse($versionRequirement);
 
 					if ($testPhpVersionConstraint->complies($this->phpstanPhpVersion)) {
 						continue;
 					}
 				} catch (UnsupportedVersionConstraintException $e) {
 					// test php-src builtin operators as in version_compare()
-					if (preg_match(self::VERSION_COMPARISON, $args[0], $matches) <= 0) {
+					if (preg_match(self::VERSION_COMPARISON, $versionRequirement, $matches) <= 0) {
 						$errors[] = RuleErrorBuilder::message(
 							sprintf($e->getMessage()),
 						)

--- a/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
+++ b/src/Rules/PHPUnit/AttributeRequiresPhpVersionRule.php
@@ -2,12 +2,16 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
+use Composer\Semver\Constraint\ConstraintInterface;
+use Composer\Semver\VersionParser;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 use function count;
 use function is_numeric;
 use function sprintf;
@@ -17,6 +21,8 @@ use function sprintf;
  */
 class AttributeRequiresPhpVersionRule implements Rule
 {
+
+	private ConstraintInterface $phpstanVersionConstraint;
 
 	private PHPUnitVersion $PHPUnitVersion;
 
@@ -30,12 +36,16 @@ class AttributeRequiresPhpVersionRule implements Rule
 	public function __construct(
 		PHPUnitVersion $PHPUnitVersion,
 		TestMethodsHelper $testMethodsHelper,
-		bool $deprecationRulesInstalled
+		bool $deprecationRulesInstalled,
+		PhpVersion $phpVersion
 	)
 	{
 		$this->PHPUnitVersion = $PHPUnitVersion;
 		$this->testMethodsHelper = $testMethodsHelper;
 		$this->deprecationRulesInstalled = $deprecationRulesInstalled;
+
+		$parser = new VersionParser();
+		$this->phpstanVersionConstraint = $parser->parseConstraints($phpVersion->getVersionString());
 	}
 
 	public function getNodeType(): string
@@ -56,6 +66,7 @@ class AttributeRequiresPhpVersionRule implements Rule
 		}
 
 		$errors = [];
+		$parser = new VersionParser();
 		foreach ($reflectionMethod->getAttributesByName('PHPUnit\Framework\Attributes\RequiresPhp') as $attr) {
 			$args = $attr->getArguments();
 			if (count($args) !== 1) {
@@ -63,28 +74,49 @@ class AttributeRequiresPhpVersionRule implements Rule
 			}
 
 			if (
-				!is_numeric($args[0])
+				is_numeric($args[0])
 			) {
+				if ($this->PHPUnitVersion->requiresPhpversionAttributeWithOperator()->yes()) {
+					$errors[] = RuleErrorBuilder::message(
+						sprintf('Version requirement is missing operator.'),
+					)
+						->identifier('phpunit.attributeRequiresPhpVersion')
+						->build();
+				} elseif (
+					$this->deprecationRulesInstalled
+					&& $this->PHPUnitVersion->deprecatesPhpversionAttributeWithoutOperator()->yes()
+				) {
+					$errors[] = RuleErrorBuilder::message(
+						sprintf('Version requirement without operator is deprecated.'),
+					)
+						->identifier('phpunit.attributeRequiresPhpVersion')
+						->build();
+				}
+
 				continue;
 			}
 
-			if ($this->PHPUnitVersion->requiresPhpversionAttributeWithOperator()->yes()) {
+			try {
+				$testPhpVersionConstraint = $parser->parseConstraints($args[0]);
+			} catch (UnexpectedValueException $e) {
 				$errors[] = RuleErrorBuilder::message(
-					sprintf('Version requirement is missing operator.'),
+					sprintf($e->getMessage()),
 				)
 					->identifier('phpunit.attributeRequiresPhpVersion')
 					->build();
-			} elseif (
-				$this->deprecationRulesInstalled
-				&& $this->PHPUnitVersion->deprecatesPhpversionAttributeWithoutOperator()->yes()
-			) {
-				$errors[] = RuleErrorBuilder::message(
-					sprintf('Version requirement without operator is deprecated.'),
-				)
-					->identifier('phpunit.attributeRequiresPhpVersion')
-					->build();
+
+				continue;
 			}
 
+			if ($this->phpstanVersionConstraint->matches($testPhpVersionConstraint)) {
+				continue;
+			}
+
+			$errors[] = RuleErrorBuilder::message(
+				sprintf('Version requirement will always evaluate to false.'),
+			)
+				->identifier('phpunit.attributeRequiresPhpVersion')
+				->build();
 		}
 
 		return $errors;

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRule.neon
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRule.neon
@@ -1,0 +1,4 @@
+parameters:
+	phpVersion:
+		min: 80200
+		max: 80400

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRuleTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PHPUnit;
+
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+
+/**
+ * @extends RuleTestCase<AttributeRequiresPhpVersionRule>
+ */
+final class AttributeRequiresPhpVersionRangeRuleTest extends RuleTestCase
+{
+
+	private int $phpVersion = 80500;
+
+	public function testPhpVersionMismatch(): void
+	{
+		$this->analyse([__DIR__ . '/data/requires-php-version-mismatch.php'], [
+			[
+				'Version requirement will always evaluate to false.',
+				20,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				28,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				36,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				44,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				76,
+			],
+		]);
+	}
+
+	protected function getRule(): Rule
+	{
+		$phpunitVersion = new PHPUnitVersion(null, null);
+
+		return new AttributeRequiresPhpVersionRule(
+			$phpunitVersion,
+			new TestMethodsHelper(
+				self::getContainer()->getByType(FileTypeMapper::class),
+				$phpunitVersion,
+			),
+			false,
+			new PhpVersion($this->phpVersion),
+		);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/AttributeRequiresPhpVersionRangeRule.neon',
+		];
+	}
+
+}

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRule.neon
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRule.neon
@@ -1,0 +1,2 @@
+parameters:
+	phpVersion: 80500

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -104,6 +104,22 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 				'Version requirement will always evaluate to false.',
 				36,
 			],
+			[
+				'Version requirement will always evaluate to false.',
+				44,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				52,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				60,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				68,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -92,6 +92,18 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 				'Version requirement will always evaluate to false.',
 				12,
 			],
+			[
+				'Version requirement will always evaluate to false.',
+				20,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				28,
+			],
+			[
+				'Version requirement will always evaluate to false.',
+				36,
+			],
 		]);
 	}
 

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -90,6 +90,7 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/requires-php-version-mismatch.php'], [
 			[
 				// errors because https://github.com/sebastianbergmann/phpunit/issues/6451
+				// the test assumes PHP_VERSION_ID 80500 and the constraint only has 2 digits
 				'Version requirement will always evaluate to false.',
 				12,
 			],

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -103,7 +103,7 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/requires-php-version-invalid.php'], [
 			[
-				'Could not parse version constraint abc: Invalid version string "abc"',
+				'Version constraint abc is not supported.',
 				12,
 			],
 		]);

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -89,6 +89,7 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/requires-php-version-mismatch.php'], [
 			[
+				// errors because https://github.com/sebastianbergmann/phpunit/issues/6451
 				'Version requirement will always evaluate to false.',
 				12,
 			],

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -155,7 +155,7 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [
-			__DIR__.'/AttributeRequiresPhpVersionRule.neon'
+			__DIR__ . '/AttributeRequiresPhpVersionRule.neon',
 		];
 	}
 

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -11,6 +12,8 @@ use PHPStan\Type\FileTypeMapper;
  */
 final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 {
+
+	private int $phpVersion = 80500;
 
 	private ?int $phpunitMajorVersion;
 
@@ -78,6 +81,34 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPhpVersionMismatch(): void
+	{
+		$this->phpunitMajorVersion = 12;
+		$this->phpunitMinorVersion = 4;
+		$this->deprecationRulesInstalled = false;
+
+		$this->analyse([__DIR__ . '/data/requires-php-version-mismatch.php'], [
+			[
+				'Version requirement will always evaluate to false.',
+				12,
+			],
+		]);
+	}
+
+	public function testInvalidPhpVersion(): void
+	{
+		$this->phpunitMajorVersion = 12;
+		$this->phpunitMinorVersion = 4;
+		$this->deprecationRulesInstalled = false;
+
+		$this->analyse([__DIR__ . '/data/requires-php-version-invalid.php'], [
+			[
+				'Could not parse version constraint abc: Invalid version string "abc"',
+				12,
+			],
+		]);
+	}
+
 	protected function getRule(): Rule
 	{
 		$phpunitVersion = new PHPUnitVersion($this->phpunitMajorVersion, $this->phpunitMinorVersion);
@@ -89,6 +120,7 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 				$phpunitVersion,
 			),
 			$this->deprecationRulesInstalled,
+			new PhpVersion($this->phpVersion),
 		);
 	}
 

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -152,4 +152,11 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 		);
 	}
 
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__.'/AttributeRequiresPhpVersionRule.neon'
+		];
+	}
+
 }

--- a/tests/Rules/PHPUnit/data/requires-php-version-invalid.php
+++ b/tests/Rules/PHPUnit/data/requires-php-version-invalid.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RequiresPhpVersionMismatch;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+
+class InvalidConstraint extends TestCase
+{
+	#[RequiresPhp('abc')]
+	public function testFoo(): void {
+
+	}
+}
+

--- a/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
+++ b/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
@@ -15,9 +15,57 @@ class RequiresPhp5 extends TestCase
 	}
 }
 
+class RequiresPhp5Caret extends TestCase
+{
+	#[RequiresPhp('^5.0')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhp5Tilde extends TestCase
+{
+	#[RequiresPhp('~5.0')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhp5Star extends TestCase
+{
+	#[RequiresPhp('5.*')]
+	public function testFoo(): void {
+
+	}
+}
+
 class RequiresPhp8 extends TestCase
 {
 	#[RequiresPhp('>=8.0')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhp8Caret extends TestCase
+{
+	#[RequiresPhp('^8.0')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhp8Tilde extends TestCase
+{
+	#[RequiresPhp('~8.0')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhp8Star extends TestCase
+{
+	#[RequiresPhp('8.*')]
 	public function testFoo(): void {
 
 	}

--- a/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
+++ b/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 
 class RequiresPhpLowerEqual85a extends TestCase
 {
-	#[RequiresPhp('<= 8.5')]
+	#[RequiresPhp('<= 8.5')] // note, version without patch component
 	public function testFoo(): void {
 
 	}
@@ -106,6 +106,14 @@ class RequiresPhp8Tilde extends TestCase
 class RequiresPhp8Star extends TestCase
 {
 	#[RequiresPhp('8.*')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhpLowerEqual853Digits extends TestCase
+{
+	#[RequiresPhp('<= 8.5.0')]
 	public function testFoo(): void {
 
 	}

--- a/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
+++ b/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace RequiresPhpVersionMismatch;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+
+class RequiresPhp5 extends TestCase
+{
+	#[RequiresPhp('< 7.0')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhp8 extends TestCase
+{
+	#[RequiresPhp('>=8.0')]
+	public function testFoo(): void {
+
+	}
+}

--- a/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
+++ b/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
@@ -7,6 +7,14 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
+class RequiresPhpLowerEqual85a extends TestCase
+{
+	#[RequiresPhp('<= 8.5')]
+	public function testFoo(): void {
+
+	}
+}
+
 class RequiresPhp5 extends TestCase
 {
 	#[RequiresPhp('< 7.0')]
@@ -34,6 +42,38 @@ class RequiresPhp5Tilde extends TestCase
 class RequiresPhp5Star extends TestCase
 {
 	#[RequiresPhp('5.*')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhpLowerEqual84 extends TestCase
+{
+	#[RequiresPhp('<= 8.4')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhpLowerEqual85 extends TestCase
+{
+	#[RequiresPhp('<= 8.5')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhp83 extends TestCase
+{
+	#[RequiresPhp('8.3.*')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhp85 extends TestCase
+{
+	#[RequiresPhp('8.5.*')]
 	public function testFoo(): void {
 
 	}

--- a/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
+++ b/tests/Rules/PHPUnit/data/requires-php-version-mismatch.php
@@ -111,9 +111,17 @@ class RequiresPhp8Star extends TestCase
 	}
 }
 
-class RequiresPhpLowerEqual853Digits extends TestCase
+class RequiresPhpLowerEqual85With3Digits extends TestCase
 {
 	#[RequiresPhp('<= 8.5.0')]
+	public function testFoo(): void {
+
+	}
+}
+
+class RequiresPhpLowerEqual86With2Digits extends TestCase
+{
+	#[RequiresPhp('<= 8.6')]
 	public function testFoo(): void {
 
 	}


### PR DESCRIPTION
- when `#[RequiresPhp]` is lower then the phpstan analysis version, reports a test requirement as beeing always false
- when `#[RequiresPhp]` contains a version which is not parse-able, reports a error