### PR TITLE
Perf: Refactor PHPUnitVersionDetector to use runtime reflection

### DIFF
--- a/src/Rules/PHPUnit/PHPUnitVersionDetector.php
+++ b/src/Rules/PHPUnit/PHPUnitVersionDetector.php
@@ -8,7 +8,6 @@ use ReflectionException;
 use function dirname;
 use function explode;
 use function file_get_contents;
-use function is_file;
 use function json_decode;
 
 class PHPUnitVersionDetector
@@ -32,16 +31,15 @@ class PHPUnitVersionDetector
 		if ($file !== false) {
 			$phpUnitRoot = dirname($file, 3);
 			$phpUnitComposer = $phpUnitRoot . '/composer.json';
-			if (is_file($phpUnitComposer)) {
-				$composerJson = @file_get_contents($phpUnitComposer);
-				if ($composerJson !== false) {
-					$json = json_decode($composerJson, true);
-					$version = $json['extra']['branch-alias']['dev-main'] ?? null;
-					if ($version !== null) {
-						$versionParts = explode('.', $version);
-						$majorVersion = (int) $versionParts[0];
-						$minorVersion = (int) $versionParts[1];
-					}
+
+			$composerJson = @file_get_contents($phpUnitComposer);
+			if ($composerJson !== false) {
+				$json = json_decode($composerJson, true);
+				$version = $json['extra']['branch-alias']['dev-main'] ?? null;
+				if ($version !== null) {
+					$versionParts = explode('.', $version);
+					$majorVersion = (int) $versionParts[0];
+					$minorVersion = (int) $versionParts[1];
 				}
 			}
 		}

--- a/src/Rules/PHPUnit/PHPUnitVersionDetector.php
+++ b/src/Rules/PHPUnit/PHPUnitVersionDetector.php
@@ -2,8 +2,9 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
-use PHPStan\Reflection\ReflectionProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionException;
 use function dirname;
 use function explode;
 use function file_get_contents;
@@ -13,33 +14,33 @@ use function json_decode;
 class PHPUnitVersionDetector
 {
 
-	private ReflectionProvider $reflectionProvider;
-
-	public function __construct(ReflectionProvider $reflectionProvider)
-	{
-		$this->reflectionProvider = $reflectionProvider;
-	}
-
 	public function createPHPUnitVersion(): PHPUnitVersion
 	{
+		$file = false;
 		$majorVersion = null;
 		$minorVersion = null;
-		if ($this->reflectionProvider->hasClass(TestCase::class)) {
-			$testCase = $this->reflectionProvider->getClass(TestCase::class);
-			$file = $testCase->getFileName();
-			if ($file !== null) {
-				$phpUnitRoot = dirname($file, 3);
-				$phpUnitComposer = $phpUnitRoot . '/composer.json';
-				if (is_file($phpUnitComposer)) {
-					$composerJson = @file_get_contents($phpUnitComposer);
-					if ($composerJson !== false) {
-						$json = json_decode($composerJson, true);
-						$version = $json['extra']['branch-alias']['dev-main'] ?? null;
-						if ($version !== null) {
-							$versionParts = explode('.', $version);
-							$majorVersion = (int) $versionParts[0];
-							$minorVersion = (int) $versionParts[1];
-						}
+
+		try {
+			// uses runtime reflection to reduce unnecessary work while bootstrapping PHPStan.
+			// static reflection would need to AST parse and build up reflection for a lot of files otherwise.
+			$reflection = new ReflectionClass(TestCase::class);
+			$file = $reflection->getFileName();
+		} catch (ReflectionException $e) {
+			// PHPUnit might not be installed
+		}
+
+		if ($file !== false) {
+			$phpUnitRoot = dirname($file, 3);
+			$phpUnitComposer = $phpUnitRoot . '/composer.json';
+			if (is_file($phpUnitComposer)) {
+				$composerJson = @file_get_contents($phpUnitComposer);
+				if ($composerJson !== false) {
+					$json = json_decode($composerJson, true);
+					$version = $json['extra']['branch-alias']['dev-main'] ?? null;
+					if ($version !== null) {
+						$versionParts = explode('.', $version);
+						$majorVersion = (int) $versionParts[0];
+						$minorVersion = (int) $versionParts[1];
 					}
 				}
 			}


### PR DESCRIPTION
before this PR running

```
➜  phpstan-src git:(2.1.x) ✗ cat foob.php                                                                                             
<?php

function doFoo(A $a)
{

}

➜  phpstan-src git:(2.1.x) ✗ bin/phpstan analyze foob.php --xdebug --debug

 ! [NOTE] You are running with "--xdebug" enabled, and the Xdebug PHP extension is active.                              
 !        The process will halt at breakpoints, but PHPStan will run much slower.                                       
 !        Use this only if you are debugging PHPStan itself or your custom extensions.                                  

Note: Using configuration file /Users/staabm/workspace/phpstan-src/phpstan.neon.dist.
/Users/staabm/workspace/phpstan-src/foob.php
 ------ ------------------------------------------------------ 
  Line   foob.php                                              
 ------ ------------------------------------------------------ 
  3      Function doFoo() has no return type specified.        
         🪪  missingType.return                                
         at foob.php:3                                         
  3      Parameter $a of function doFoo() has invalid type A.  
         🪪  class.notFound                                    
         at foob.php:3                                         
 ------ ------------------------------------------------------ 


                                                                                                                        
 [ERROR] Found 2 errors                                                                                                                                                                                                                    
```

would invoke `FileReader::readFile()` 188 times.

after this PR it is only invoked 62 times.

-> we reduce bootstrap overhead when projects have phpstan-phpunit installed
-> similar idea as in https://github.com/phpstan/phpstan-src/pull/4491, refs https://github.com/phpstan/build-infection/issues/16

----

using https://github.com/phpstan/phpstan-src/commit/38ea1ab99430733be04c4044f61201ae9dfa7d5e

before this PR:

```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'bin/phpstan analyze foob.php --debug' -i
Benchmark 1: bin/phpstan analyze foob.php --debug
  Time (mean ± σ):     749.7 ms ±   6.1 ms    [User: 577.5 ms, System: 167.0 ms]
  Range (min … max):   745.0 ms … 762.4 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 ```
after this PR:

```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'bin/phpstan analyze foob.php --debug' -i
Benchmark 1: bin/phpstan analyze foob.php --debug
  Time (mean ± σ):     726.2 ms ±  16.3 ms    [User: 550.9 ms, System: 169.2 ms]
  Range (min … max):   715.0 ms … 769.7 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 ```

