### PR TITLE
Implement DynamicCallToAssertionIgnoreExtension

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -72,8 +72,13 @@ services:
 	-
 		class: PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension
 
+	-
+		class: PHPStan\Type\PHPUnit\DynamicCallToAssertionIgnoreExtension
+
 conditionalTags:
 	PHPStan\PhpDoc\PHPUnit\MockObjectTypeNodeResolverExtension:
 		phpstan.phpDoc.typeNodeResolverExtension: %phpunit.convertUnionToIntersectionType%
 	PHPStan\Type\PHPUnit\DataProviderReturnTypeIgnoreExtension:
 		phpstan.ignoreErrorExtension: [%featureToggles.bleedingEdge%, not(%phpunit.reportMissingDataProviderReturnType%)]
+	PHPStan\Type\PHPUnit\DynamicCallToAssertionIgnoreExtension:
+		phpstan.ignoreErrorExtension: %featureToggles.bleedingEdge%

--- a/src/Type/PHPUnit/DynamicCallToAssertionIgnoreExtension.php
+++ b/src/Type/PHPUnit/DynamicCallToAssertionIgnoreExtension.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\PHPUnit;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\IgnoreErrorExtension;
+use PHPStan\Analyser\Scope;
+use PHPUnit\Framework\TestCase;
+use function is_string;
+use function str_starts_with;
+
+final class DynamicCallToAssertionIgnoreExtension implements IgnoreErrorExtension
+{
+
+	public function shouldIgnore(Error $error, Node $node, Scope $scope): bool
+	{
+		if (!$node instanceof Node\Expr\MethodCall) {
+			return false;
+		}
+
+		if (!$node->var instanceof Node\Expr\Variable) {
+			return false;
+		}
+
+		if (!is_string($node->var->name) || $node->var->name !== 'this') {
+			return false;
+		}
+
+		if ($error->getIdentifier() !== 'staticMethod.dynamicCall') {
+			return false;
+		}
+
+		if (
+			!$node->name instanceof Node\Identifier
+			|| !str_starts_with($node->name->name, 'assert')
+		) {
+			return false;
+		}
+
+		if (!$scope->isInClass()) {
+			return false;
+		}
+
+		$classReflection = $scope->getClassReflection();
+		return $classReflection->is(TestCase::class);
+	}
+
+}

--- a/tests/Type/PHPUnit/DynamicCallToAssertionIgnoreExtensionTest.php
+++ b/tests/Type/PHPUnit/DynamicCallToAssertionIgnoreExtensionTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\PHPUnit;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\StrictCalls\DynamicCallOnStaticMethodsRule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<DynamicCallOnStaticMethodsRule>
+ */
+class DynamicCallToAssertionIgnoreExtensionTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		/** @phpstan-ignore phpstanApi.classConstant */
+		return self::getContainer()->getByType(DynamicCallOnStaticMethodsRule::class);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/dynamic-call-to-assertion.php'], [
+			[
+				'Dynamic call to static method DynamicCallToAssertion\Foo::staticFn().',
+				17,
+			],
+		]);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/data/dynamic-call-to-assertion.neon',
+		];
+	}
+
+}

--- a/tests/Type/PHPUnit/data/dynamic-call-to-assertion.neon
+++ b/tests/Type/PHPUnit/data/dynamic-call-to-assertion.neon
@@ -1,0 +1,10 @@
+parameters:
+	featureToggles:
+		bleedingEdge: true
+
+includes:
+	- ../../../../extension.neon
+
+services:
+	-
+		class: PHPStan\Rules\StrictCalls\DynamicCallOnStaticMethodsRule

--- a/tests/Type/PHPUnit/data/dynamic-call-to-assertion.php
+++ b/tests/Type/PHPUnit/data/dynamic-call-to-assertion.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DynamicCallToAssertion;
+
+use PHPUnit\Framework\TestCase;
+
+class Foo extends TestCase {
+	public function testFoo(bool $b):void {
+		$this->assertTrue($b);
+	}
+
+	public function testBar(bool $b):void {
+		self::assertTrue($b);
+	}
+
+	public function foo():void {
+		$x = $this->staticFn();
+	}
+
+	static protected function staticFn():bool {
+		return true;
+	}
+}


### PR DESCRIPTION
as discussed in https://github.com/phpstan/phpstan-src/pull/4654

---

we use a `IgnoreErrorExtension` to prevent slow regex re-validation of ignore patterns like

```
	ignoreErrors:
		- '#^Dynamic call to static method PHPUnit\\Framework\\\S+\(\)\.$#'
```