### PR TITLE
DataProviderDataRule: Optimize hot path

### DIFF
--- a/src/Rules/PHPUnit/DataProviderDataRule.php
+++ b/src/Rules/PHPUnit/DataProviderDataRule.php
@@ -58,18 +58,13 @@ class DataProviderDataRule implements Rule
 			return [];
 		}
 
-		$arraysTypes = $this->buildArrayTypesFromNode($node, $scope);
-		if ($arraysTypes === []) {
-			return [];
-		}
-
-		$method = $scope->getFunction();
 		$classReflection = $scope->getClassReflection();
 		if ($classReflection === null) {
 			return [];
 		}
 
 		$testsWithProvider = [];
+		$method = $scope->getFunction();
 		$testMethods = $this->testMethodsHelper->getTestMethods($classReflection, $scope);
 		foreach ($testMethods as $testMethod) {
 			foreach ($this->dataProviderHelper->getDataProviderMethods($scope, $testMethod, $classReflection) as [, $providerMethodName]) {
@@ -81,6 +76,11 @@ class DataProviderDataRule implements Rule
 		}
 
 		if (count($testsWithProvider) === 0) {
+			return [];
+		}
+
+		$arraysTypes = $this->buildArrayTypesFromNode($node, $scope);
+		if ($arraysTypes === []) {
 			return [];
 		}
 

--- a/src/Rules/PHPUnit/TestMethodsHelper.php
+++ b/src/Rules/PHPUnit/TestMethodsHelper.php
@@ -48,11 +48,12 @@ final class TestMethodsHelper
 	 */
 	public function getTestMethods(ClassReflection $classReflection, Scope $scope): array
 	{
-		if (array_key_exists($classReflection->getName(), $this->methodCache)) {
-			return $this->methodCache[$classReflection->getName()];
+		$className = $classReflection->getName();
+		if (array_key_exists($className, $this->methodCache)) {
+			return $this->methodCache[$className];
 		}
 		if (!$classReflection->is(TestCase::class)) {
-			return $this->methodCache[$classReflection->getName()] = [];
+			return $this->methodCache[$className] = [];
 		}
 
 		$testMethods = [];
@@ -70,7 +71,7 @@ final class TestMethodsHelper
 			if ($docComment !== null) {
 				$methodPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
 					$scope->getFile(),
-					$classReflection->getName(),
+					$className,
 					$scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
 					$reflectionMethod->getName(),
 					$docComment,
@@ -94,7 +95,7 @@ final class TestMethodsHelper
 			$testMethods[] = $reflectionMethod;
 		}
 
-		return $this->methodCache[$classReflection->getName()] = $testMethods;
+		return $this->methodCache[$className] = $testMethods;
 	}
 
 	private function hasTestAnnotation(?ResolvedPhpDocBlock $phpDoc): bool


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan/issues/14072#issuecomment-3901259495

reduces the cost when analyzing non-test methods return/yield/yield-from which is a very very common case.

before PR

<img width="434" height="759" alt="grafik" src="https://github.com/user-attachments/assets/640e1888-e32b-422c-aaa5-8ecb823e4491" />


after PR

<img width="441" height="434" alt="grafik" src="https://github.com/user-attachments/assets/d6e30d5a-1eae-4875-be62-b01edf12ca0e" />
