### PR TITLE
name-collision-detector

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@
 /phpstan-baseline.neon export-ignore
 /phpunit.xml export-ignore
 /CLAUDE.md export-ignore
+collision-detector.json export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,3 +317,29 @@ jobs:
         with:
           path: ./tmp
           key: "result-cache-v1-${{ matrix.php-version }}-${{ github.run_id }}"
+
+  name-collision:
+    name: "Name Collision Detector"
+
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 60
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
+        with:
+          egress-policy: audit
+
+      - name: "Checkout"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1" # v2
+        with:
+          coverage: "none"
+          php-version: "8.5"
+
+      - uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # v3
+
+      - name: "Name Collision Detector"
+        run: "make name-collision"

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,6 @@ phpstan:
 .PHONY: phpstan-generate-baseline
 phpstan-generate-baseline:
 	php vendor/bin/phpstan analyse -c phpstan.neon -b phpstan-baseline.neon
+
+name-collision:
+	php vendor/bin/detect-collisions --configuration collision-detector.json

--- a/collision-detector.json
+++ b/collision-detector.json
@@ -1,0 +1,3 @@
+{
+  "scanPaths": ["src", "tests"]
+}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"phpstan/phpstan-deprecation-rules": "^2.0",
 		"phpstan/phpstan-strict-rules": "^2.0",
-		"phpunit/phpunit": "^9.6"
+		"phpunit/phpunit": "^9.6",
+		"shipmonk/name-collision-detector": "^2.1"
 	},
 	"config": {
 		"sort-packages": true

--- a/tests/Rules/PHPUnit/data/assert-same.php
+++ b/tests/Rules/PHPUnit/data/assert-same.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace ExampleTestCase;
+namespace ExampleTestCaseAsserts;
 
 class FooTestCase extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Type/PHPUnit/data/assert-function-9.6.11.php
+++ b/tests/Type/PHPUnit/data/assert-function-9.6.11.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AssertFunction;
+namespace AssertFunction96;
 
 use function PHPStan\Testing\assertType;
 use function PHPUnit\Framework\assertObjectHasProperty;


### PR DESCRIPTION
to prevent duplicate symbols like in https://github.com/phpstan/phpstan-doctrine/pull/743#discussion_r3186143456

inspired by https://github.com/phpstan/phpstan-src/commit/95cdbe577513286c36dcf513fe76f269e8a32125#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2

----

fixes

```
➜  phpstan-phpunit git:(clean) make name-collision
php vendor/bin/detect-collisions --configuration collision-detector.json
Using config '/Users/staabm/workspace/phpstan-phpunit/collision-detector.json'

AssertFunction\Foo is defined 2 times:
 > /tests/Type/PHPUnit/data/assert-function-9.6.11.php:8
 > /tests/Type/PHPUnit/data/assert-function.php:15

ExampleTestCase\FooTestCase is defined 2 times:
 > /tests/Rules/PHPUnit/data/assert-same.php:5
 > /tests/Rules/PHPUnit/data/data-provider-declaration.php:7


make: *** [name-collision] Error 1
```