### PR TITLE
latest infection does not support PHP 8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "8.2"
           - "8.3"
           - "8.4"
           - "8.5"


### PR DESCRIPTION
https://github.com/phpstan/phpstan-doctrine/pull/752