### PR TITLE
AttributeVersionRequirementHelper: add defaults to bool parameters

### DIFF
--- a/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
+++ b/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
@@ -43,9 +43,9 @@ final class AttributeVersionRequirementHelper
 
 	public function __construct(
 		PHPUnitVersion $PHPUnitVersion,
-		bool $deprecationRulesInstalled,
 		PhpVersion $phpVersion,
-		bool $bleedingEdge,
+		bool $deprecationRulesInstalled = false,
+		bool $bleedingEdge = false,
 		bool $warnAboutIncompleteVersion = true
 	)
 	{

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRuleTest.php
@@ -52,8 +52,8 @@ final class AttributeRequiresPhpVersionRangeRuleTest extends RuleTestCase
 			),
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				false,
 				new PhpVersion($this->phpVersion),
+				false,
 				true,
 			),
 		);

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -196,8 +196,8 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 			),
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				$this->deprecationRulesInstalled,
 				new PhpVersion($this->phpVersion),
+				$this->deprecationRulesInstalled,
 				true,
 				$this->warnAboutIncompleteVersion,
 			),

--- a/tests/Rules/PHPUnit/ClassAttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/ClassAttributeRequiresPhpVersionRuleTest.php
@@ -59,8 +59,8 @@ final class ClassAttributeRequiresPhpVersionRuleTest extends RuleTestCase
 		return new ClassAttributeRequiresPhpVersionRule(
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				false,
 				new PhpVersion($this->phpVersion),
+				false,
 				true,
 				$this->warnAboutIncompleteVersion,
 			),


### PR DESCRIPTION
should fix phpstan-src CI error in e2e/result-cache-restore-without-reflection:

```
In Resolver.php line 677:
                                                                               
  [Nette\DI\ServiceCreationException]                                          
  Service of type PHPStan\Rules\PHPUnit\AttributeRequiresPhpVersionRule: Para  
  meter $deprecationRulesInstalled in AttributeRequiresPhpVersionRule::__cons  
  truct() has no class type or default value, so its value must be specified.  
                                                                               

Exception trace:
  at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Resolver.php:677
 Nette\DI\Resolver::autowireArgument() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Resolver.php:572
 Nette\DI\Resolver::autowireArguments() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Resolver.php:229
 Nette\DI\Resolver->completeStatement() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Definitions/ServiceDefinition.php:178
 Nette\DI\Definitions\ServiceDefinition->complete() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Resolver.php:173
 Nette\DI\Resolver->completeDefinition() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/ContainerBuilder.php:338
 Nette\DI\ContainerBuilder->complete() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Compiler.php:275
 Nette\DI\Compiler->processBeforeCompile() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/Compiler.php:212
 Nette\DI\Compiler->compile() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/ContainerLoader.php:119
 Nette\DI\ContainerLoader->generate() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/ContainerLoader.php:80
 Nette\DI\ContainerLoader->loadFile() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/di/src/DI/ContainerLoader.php:44
 Nette\DI\ContainerLoader->load() at /home/runner/work/phpstan-src/phpstan-src/src/DependencyInjection/Configurator.php:111
 PHPStan\DependencyInjection\Configurator->loadContainer() at /home/runner/work/phpstan-src/phpstan-src/vendor/nette/bootstrap/src/Bootstrap/Configurator.php:258
```