### PR TITLE
Fix `#[RequiresPhpunit]` version requirement being evaluated against PHP version

### DIFF
--- a/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
+++ b/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
@@ -17,6 +17,7 @@ use function count;
 use function is_numeric;
 use function preg_match;
 use function sprintf;
+use function strpos;
 use function substr_count;
 use function version_compare;
 
@@ -96,11 +97,18 @@ final class AttributeVersionRequirementHelper
 					continue;
 				}
 
+				$pharIoVersions = strpos($attr->getName(), 'RequiresPhpunit') !== false
+					? $this->PHPUnitVersion->getPharIoVersions()
+					: $phpstanPharIoVersions;
+				if ($pharIoVersions === []) {
+					continue;
+				}
+
 				try {
 					// check composer like version constraints, e.g. ^1  or ~2
 					$testPhpVersionConstraint = $parser->parse($versionRequirement);
 
-					foreach ($phpstanPharIoVersions as $pharIoVersion) {
+					foreach ($pharIoVersions as $pharIoVersion) {
 						if ($testPhpVersionConstraint->complies($pharIoVersion)) {
 							// one of the versions within range matched, check next attribute
 							continue 2;
@@ -120,7 +128,7 @@ final class AttributeVersionRequirementHelper
 
 					$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
 
-					foreach ($phpstanPharIoVersions as $pharIoVersion) {
+					foreach ($pharIoVersions as $pharIoVersion) {
 						if (version_compare($pharIoVersion->getVersionString(), $matches['version'], $operator)) {
 							// one of the versions within range matched, check next attribute
 							continue 2;

--- a/src/Rules/PHPUnit/PHPUnitVersion.php
+++ b/src/Rules/PHPUnit/PHPUnitVersion.php
@@ -2,7 +2,9 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
+use PharIo\Version\Version;
 use PHPStan\TrinaryLogic;
+use function sprintf;
 
 class PHPUnitVersion
 {
@@ -15,6 +17,21 @@ class PHPUnitVersion
 	{
 		$this->majorVersion = $majorVersion;
 		$this->minorVersion = $minorVersion;
+	}
+
+	/**
+	 * @return array{}|array{Version, Version}
+	 */
+	public function getPharIoVersions(): array
+	{
+		if ($this->majorVersion === null || $this->minorVersion === null) {
+			return [];
+		}
+
+		return [
+			new Version(sprintf('%d.%d.0', $this->majorVersion, $this->minorVersion)),
+			new Version(sprintf('%d.%d.99', $this->majorVersion, $this->minorVersion)),
+		];
 	}
 
 	public function supportsDataProviderAttribute(): TrinaryLogic

--- a/tests/Rules/PHPUnit/data/requires-phpunit-version.php
+++ b/tests/Rules/PHPUnit/data/requires-phpunit-version.php
@@ -9,13 +9,13 @@ use PHPUnit\Framework\Attributes\RequiresPhpunit;
 
 class TwoDigitVersionA extends TestCase
 {
-	#[RequiresPhpunit('8.0')]
+	#[RequiresPhpunit('11.0')]
 	public function testFoo(): void {
 
 	}
 }
 
-#[RequiresPhpunit('>=8.0')]
+#[RequiresPhpunit('>=11.0')]
 class TwoDigitVersionB extends TestCase
 {
 	public function testBar(): void {
@@ -25,13 +25,18 @@ class TwoDigitVersionB extends TestCase
 
 class CorrectRequirement extends TestCase
 {
-	#[RequiresPhpunit('>=8.0.0')]
+	#[RequiresPhpunit('>=11.0.0')]
 	public function testBar(): void {
+
+	}
+
+	#[RequiresPhpunit('^12.0.0')]
+	public function testBaz(): void {
 
 	}
 }
 
-#[RequiresPhpunit('>=8.0.0')]
+#[RequiresPhpunit('>=11.0.0')]
 class CorrectClassRequirement extends TestCase
 {
 	public function testBar(): void {


### PR DESCRIPTION
Currently, the `#[RequiresPhpunit]` requirement is evaluated against the analysed PHP version, so constraints like `^11.0.0` are reported as "always evaluate to false" even with PHPUnit 11.5 installed.