### PR TITLE
Fix PHPVersion based checks

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
           - script: |
               cd e2e/composer-version
               composer install
-              OUTPUT=$(../bashunit -a exit_code "1" "vendor/bin/phpstan --error-format=raw")
+              OUTPUT=$(../bashunit -a exit_code "1" "vendor/bin/phpstan analyze test.php --error-format=raw")
               echo "$OUTPUT"
               ../bashunit -a contains 'test.php:12:Version requirement will always evaluate to false.' "$OUTPUT"
               ../bashunit -a contains 'test.php:32:Version requirement will always evaluate to false.' "$OUTPUT"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
           - script: |
               cd e2e/composer-version
               composer install
-              OUTPUT=$(../bashunit -a exit_code "1" "vendor/bin/phpstan --error-format=raw)
+              OUTPUT=$(../bashunit -a exit_code "1" "vendor/bin/phpstan --error-format=raw")
               echo "$OUTPUT"
               ../bashunit -a contains 'test.php:12:Version requirement will always evaluate to false.' "$OUTPUT"
               ../bashunit -a contains 'test.php:32:Version requirement will always evaluate to false.' "$OUTPUT"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,7 +28,10 @@ jobs:
           - script: |
               cd e2e/composer-version
               composer install
-              vendor/bin/phpstan
+              OUTPUT=$(../bashunit -a exit_code "1" "vendor/bin/phpstan --error-format=raw)
+              echo "$OUTPUT"
+              ../bashunit -a contains 'test.php:12:Version requirement will always evaluate to false.' "$OUTPUT"
+              ../bashunit -a contains 'test.php:32:Version requirement will always evaluate to false.' "$OUTPUT"
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,56 @@
+# https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+
+name: "E2E Tests"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "2.0.x"
+
+concurrency:
+  group: e2e-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-tests:
+    name: "E2E tests"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - script: |
+              cd e2e/composer-version
+              composer install
+              vendor/bin/phpstan
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: "Checkout"
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc" # v2.37.1
+        with:
+          coverage: "none"
+          php-version: "8.3"
+
+      - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # v4.0.0
+
+      - name: "Install bashunit"
+        uses: "TypedDevs/bashunit@ffa9c79e71ecbb9990e777348bc9ba12314b62d0" # 0.39.1
+        with:
+          directory: "e2e"
+
+      - name: "Test"
+        run: ${{ matrix.script }}

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"phar-io/version": "^3.2",
-		"phpstan/phpstan": "^2.2.3"
+		"phpstan/phpstan": "^2.2.6"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"

--- a/e2e/composer-version/.gitignore
+++ b/e2e/composer-version/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock

--- a/e2e/composer-version/composer.json
+++ b/e2e/composer-version/composer.json
@@ -1,0 +1,22 @@
+{
+	"require": {
+		"php": "^8.1",
+		"phpstan/phpstan": "@dev",
+		"phpstan/phpstan-phpunit": "@dev"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../"
+		}
+	],
+	"require-dev": {
+		"phpunit/phpunit": "^12.5",
+		"phpstan/extension-installer": "^1.4"
+	},
+	"config": {
+		"allow-plugins": {
+			"phpstan/extension-installer": true
+		}
+	}
+}

--- a/e2e/composer-version/composer.json
+++ b/e2e/composer-version/composer.json
@@ -2,7 +2,9 @@
 	"require": {
 		"php": "^8.1",
 		"phpstan/phpstan": "@dev",
-		"phpstan/phpstan-phpunit": "@dev"
+		"phpstan/phpstan-phpunit": "@dev",
+		"phpunit/phpunit": "^12.5",
+		"phpstan/extension-installer": "^1.4"
 	},
 	"repositories": [
 		{
@@ -10,10 +12,6 @@
 			"url": "../../"
 		}
 	],
-	"require-dev": {
-		"phpunit/phpunit": "^12.5",
-		"phpstan/extension-installer": "^1.4"
-	},
 	"config": {
 		"allow-plugins": {
 			"phpstan/extension-installer": true

--- a/e2e/composer-version/phpstan.neon
+++ b/e2e/composer-version/phpstan.neon
@@ -1,0 +1,2 @@
+includes:
+	- phar://phpstan.phar/conf/bleedingEdge.neon

--- a/e2e/composer-version/phpstan.neon
+++ b/e2e/composer-version/phpstan.neon
@@ -1,2 +1,5 @@
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
+
+parameters:
+	level: 5

--- a/e2e/composer-version/test.php
+++ b/e2e/composer-version/test.php
@@ -1,6 +1,7 @@
 <?php
 
 use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpunit;
 
 class A extends \PHPUnit\Framework\TestCase {
 	#[RequiresPhp('<=8.2.0')]
@@ -19,5 +20,15 @@ class C extends \PHPUnit\Framework\TestCase {
 
 class D extends \PHPUnit\Framework\TestCase {
 	#[RequiresPhp('^8.1.0')]
+	public function testFoo() {}
+}
+
+class E extends \PHPUnit\Framework\TestCase {
+	#[RequiresPhpunit('^12.0.0')]
+	public function testFoo() {}
+}
+
+class F extends \PHPUnit\Framework\TestCase {
+	#[RequiresPhpunit('^11.0.0')]
 	public function testFoo() {}
 }

--- a/e2e/composer-version/test.php
+++ b/e2e/composer-version/test.php
@@ -1,0 +1,23 @@
+<?php
+
+use PHPUnit\Framework\Attributes\RequiresPhp;
+
+class A extends \PHPUnit\Framework\TestCase {
+	#[RequiresPhp('<=8.2.0')]
+	public function testFoo() {}
+}
+
+class B extends \PHPUnit\Framework\TestCase {
+	#[RequiresPhp('<=8.0.0')]
+	public function testFoo() {}
+}
+
+class C extends \PHPUnit\Framework\TestCase {
+	#[RequiresPhp('^8.0.0')]
+	public function testFoo() {}
+}
+
+class D extends \PHPUnit\Framework\TestCase {
+	#[RequiresPhp('^8.1.0')]
+	public function testFoo() {}
+}

--- a/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
+++ b/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
@@ -7,17 +7,14 @@ use PharIo\Version\Version;
 use PharIo\Version\VersionConstraintParser;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Reflection\ReflectionAttribute;
+use PHPStan\Php\ConfiguredPhpVersionRangeHelper;
 use PHPStan\Php\PhpMinorVersionIterator;
-use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\Constant\ConstantIntegerType;
-use PHPStan\Type\IntegerRangeType;
 use function count;
 use function is_numeric;
 use function preg_match;
 use function sprintf;
-use function strpos;
 use function substr_count;
 use function version_compare;
 
@@ -27,8 +24,6 @@ final class AttributeVersionRequirementHelper
 	private const VERSION_COMPARISON = "/(?P<operator>!=|<|<=|<>|=|==|>|>=)?\s*(?P<version>[\d\.-]+(dev|(RC|alpha|beta)[\d\.])?)[ \t]*\r?$/m";
 
 	private PHPUnitVersion $PHPUnitVersion;
-
-	private PhpVersion $fallbackPhpVersion;
 
 	/**
 	 * When phpstan-deprecation-rules is installed, rule reports deprecated usages.
@@ -42,9 +37,11 @@ final class AttributeVersionRequirementHelper
 
 	private bool $bleedingEdge;
 
+	private ConfiguredPhpVersionRangeHelper $phpVersionRangeHelper;
+
 	public function __construct(
 		PHPUnitVersion $PHPUnitVersion,
-		PhpVersion $phpVersion,
+		ConfiguredPhpVersionRangeHelper $phpVersionRangeHelper,
 		bool $deprecationRulesInstalled = false,
 		bool $bleedingEdge = false,
 		bool $warnAboutIncompleteVersion = true
@@ -52,9 +49,9 @@ final class AttributeVersionRequirementHelper
 	{
 		$this->PHPUnitVersion = $PHPUnitVersion;
 		$this->deprecationRulesInstalled = $deprecationRulesInstalled;
-		$this->fallbackPhpVersion = $phpVersion;
 		$this->warnAboutIncompleteVersion = $warnAboutIncompleteVersion;
 		$this->bleedingEdge = $bleedingEdge;
+		$this->phpVersionRangeHelper = $phpVersionRangeHelper;
 	}
 
 	/**
@@ -64,7 +61,7 @@ final class AttributeVersionRequirementHelper
 	 */
 	public function checkVersionRequirement(array $attributes, Scope $scope): array
 	{
-		$phpstanPharIoVersions = $this->getAnalyzedPhpVersions($scope);
+		$phpstanPharIoVersions = $this->getAnalyzedPhpVersions();
 		if ($phpstanPharIoVersions === []) {
 			return [];
 		}
@@ -97,18 +94,11 @@ final class AttributeVersionRequirementHelper
 					continue;
 				}
 
-				$pharIoVersions = strpos($attr->getName(), 'RequiresPhpunit') !== false
-					? $this->PHPUnitVersion->getPharIoVersions()
-					: $phpstanPharIoVersions;
-				if ($pharIoVersions === []) {
-					continue;
-				}
-
 				try {
 					// check composer like version constraints, e.g. ^1  or ~2
 					$testPhpVersionConstraint = $parser->parse($versionRequirement);
 
-					foreach ($pharIoVersions as $pharIoVersion) {
+					foreach ($phpstanPharIoVersions as $pharIoVersion) {
 						if ($testPhpVersionConstraint->complies($pharIoVersion)) {
 							// one of the versions within range matched, check next attribute
 							continue 2;
@@ -128,7 +118,7 @@ final class AttributeVersionRequirementHelper
 
 					$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
 
-					foreach ($pharIoVersions as $pharIoVersion) {
+					foreach ($phpstanPharIoVersions as $pharIoVersion) {
 						if (version_compare($pharIoVersion->getVersionString(), $matches['version'], $operator)) {
 							// one of the versions within range matched, check next attribute
 							continue 2;
@@ -168,21 +158,14 @@ final class AttributeVersionRequirementHelper
 	/**
 	 * @return Version[]
 	 */
-	private function getAnalyzedPhpVersions(Scope $scope): array
+	private function getAnalyzedPhpVersions(): array
 	{
-		$scopePhpVersion = $scope->getPhpVersion()->getType();
-		if ($scopePhpVersion instanceof ConstantIntegerType) {
-			$v = new PhpVersion($scopePhpVersion->getValue());
-			return [new Version($v->getVersionString())];
-		} elseif ($scopePhpVersion instanceof IntegerRangeType) {
-			if ($scopePhpVersion->getMin() === null || $scopePhpVersion->getMax() === null) {
-				return [];
-			}
-
+		[$minVersion, $maxVersion] = $this->phpVersionRangeHelper->getVersionRange();
+		if ($minVersion !== null && $maxVersion !== null) {
 			$versions = [];
 			$minorVersionIterator = new PhpMinorVersionIterator(
-				new PhpVersion($scopePhpVersion->getMin()),
-				new PhpVersion($scopePhpVersion->getMax()),
+				$minVersion,
+				$maxVersion,
 			);
 			foreach ($minorVersionIterator as $phpstanVersion) {
 				$versions[] = new Version($phpstanVersion->getVersionString());
@@ -190,7 +173,7 @@ final class AttributeVersionRequirementHelper
 			return $versions;
 		}
 
-		return [new Version($this->fallbackPhpVersion->getVersionString())];
+		return [];
 	}
 
 	// see https://github.com/sebastianbergmann/phpunit/issues/6451

--- a/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
+++ b/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
@@ -15,6 +15,7 @@ use function count;
 use function is_numeric;
 use function preg_match;
 use function sprintf;
+use function strpos;
 use function substr_count;
 use function version_compare;
 
@@ -162,6 +163,7 @@ final class AttributeVersionRequirementHelper
 	 */
 	private function getAnalyzedPhpVersions(): array
 	{
+		// @phpstan-ignore phpstanApi.method
 		[$minVersion, $maxVersion] = $this->phpVersionRangeHelper->getVersionRange();
 		if ($minVersion !== null && $maxVersion !== null) {
 			$versions = [];

--- a/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
+++ b/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
@@ -61,11 +61,6 @@ final class AttributeVersionRequirementHelper
 	 */
 	public function checkVersionRequirement(array $attributes, Scope $scope): array
 	{
-		$phpstanPharIoVersions = $this->getAnalyzedPhpVersions();
-		if ($phpstanPharIoVersions === []) {
-			return [];
-		}
-
 		$errors = [];
 		$parser = new VersionConstraintParser();
 		foreach ($attributes as $attr) {
@@ -94,11 +89,18 @@ final class AttributeVersionRequirementHelper
 					continue;
 				}
 
+				$pharIoVersions = strpos($attr->getName(), 'RequiresPhpunit') !== false
+					? $this->PHPUnitVersion->getPharIoVersions()
+					: $this->getAnalyzedPhpVersions();
+				if ($pharIoVersions === []) {
+					continue;
+				}
+
 				try {
 					// check composer like version constraints, e.g. ^1  or ~2
 					$testPhpVersionConstraint = $parser->parse($versionRequirement);
 
-					foreach ($phpstanPharIoVersions as $pharIoVersion) {
+					foreach ($pharIoVersions as $pharIoVersion) {
 						if ($testPhpVersionConstraint->complies($pharIoVersion)) {
 							// one of the versions within range matched, check next attribute
 							continue 2;
@@ -118,7 +120,7 @@ final class AttributeVersionRequirementHelper
 
 					$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
 
-					foreach ($phpstanPharIoVersions as $pharIoVersion) {
+					foreach ($pharIoVersions as $pharIoVersion) {
 						if (version_compare($pharIoVersion->getVersionString(), $matches['version'], $operator)) {
 							// one of the versions within range matched, check next attribute
 							continue 2;

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRuleTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
-use PHPStan\Php\PhpVersion;
+use PHPStan\Php\ConfiguredPhpVersionRangeHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -12,8 +12,6 @@ use PHPStan\Type\FileTypeMapper;
  */
 final class AttributeRequiresPhpVersionRangeRuleTest extends RuleTestCase
 {
-
-	private int $phpVersion = 80500;
 
 	public function testPhpVersionMismatch(): void
 	{
@@ -52,7 +50,7 @@ final class AttributeRequiresPhpVersionRangeRuleTest extends RuleTestCase
 			),
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				new PhpVersion($this->phpVersion),
+				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class),
 				false,
 				true,
 			),

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRangeRuleTest.php
@@ -50,7 +50,7 @@ final class AttributeRequiresPhpVersionRangeRuleTest extends RuleTestCase
 			),
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class),
+				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class), // @phpstan-ignore phpstanApi.classConstant
 				false,
 				true,
 			),

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRule.neon
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRule.neon
@@ -1,2 +1,4 @@
 parameters:
-	phpVersion: 80500
+	phpVersion:
+		min: 80500
+		max: 80599

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -194,7 +194,7 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 			),
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class),
+				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class), // @phpstan-ignore phpstanApi.classConstant
 				$this->deprecationRulesInstalled,
 				true,
 				$this->warnAboutIncompleteVersion,

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
-use PHPStan\Php\PhpVersion;
+use PHPStan\Php\ConfiguredPhpVersionRangeHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;
@@ -12,8 +12,6 @@ use PHPStan\Type\FileTypeMapper;
  */
 final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 {
-
-	private int $phpVersion = 80500;
 
 	private ?int $phpunitMajorVersion;
 
@@ -196,7 +194,7 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 			),
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				new PhpVersion($this->phpVersion),
+				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class),
 				$this->deprecationRulesInstalled,
 				true,
 				$this->warnAboutIncompleteVersion,

--- a/tests/Rules/PHPUnit/AttributeRequiresSinglePhpVersionRule.neon
+++ b/tests/Rules/PHPUnit/AttributeRequiresSinglePhpVersionRule.neon
@@ -1,0 +1,2 @@
+parameters:
+	phpVersion: 80210

--- a/tests/Rules/PHPUnit/AttributeRequiresSinglePhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresSinglePhpVersionRuleTest.php
@@ -1,12 +1,8 @@
 <?php declare(strict_types = 1);
 
-namespace Rules\PHPUnit;
+namespace PHPStan\Rules\PHPUnit;
 
 use PHPStan\Php\ConfiguredPhpVersionRangeHelper;
-use PHPStan\Rules\PHPUnit\AttributeRequiresPhpVersionRule;
-use PHPStan\Rules\PHPUnit\AttributeVersionRequirementHelper;
-use PHPStan\Rules\PHPUnit\PHPUnitVersion;
-use PHPStan\Rules\PHPUnit\TestMethodsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\FileTypeMapper;

--- a/tests/Rules/PHPUnit/AttributeRequiresSinglePhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresSinglePhpVersionRuleTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace Rules\PHPUnit;
+
+use PHPStan\Php\ConfiguredPhpVersionRangeHelper;
+use PHPStan\Rules\PHPUnit\AttributeRequiresPhpVersionRule;
+use PHPStan\Rules\PHPUnit\AttributeVersionRequirementHelper;
+use PHPStan\Rules\PHPUnit\PHPUnitVersion;
+use PHPStan\Rules\PHPUnit\TestMethodsHelper;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\FileTypeMapper;
+
+/**
+ * @extends RuleTestCase<AttributeRequiresPhpVersionRule>
+ */
+final class AttributeRequiresSinglePhpVersionRuleTest extends RuleTestCase
+{
+
+	public function testPhpVersionMismatch(): void
+	{
+		$this->analyse([__DIR__ . '/data/requires-php-version-mismatch.php'], []);
+	}
+
+	protected function getRule(): Rule
+	{
+		$phpunitVersion = new PHPUnitVersion(null, null);
+
+		return new AttributeRequiresPhpVersionRule(
+			new TestMethodsHelper(
+				self::getContainer()->getByType(FileTypeMapper::class),
+				$phpunitVersion,
+			),
+			new AttributeVersionRequirementHelper(
+				$phpunitVersion,
+				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class), // @phpstan-ignore phpstanApi.classConstant
+				false,
+				true,
+			),
+		);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/AttributeRequiresSinglePhpVersionRule.neon',
+		];
+	}
+
+}

--- a/tests/Rules/PHPUnit/ClassAttributeRequiresPhpVersionRule.neon
+++ b/tests/Rules/PHPUnit/ClassAttributeRequiresPhpVersionRule.neon
@@ -1,2 +1,4 @@
 parameters:
-	phpVersion: 80500
+	phpVersion:
+		min: 80500
+		max: 80599

--- a/tests/Rules/PHPUnit/ClassAttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/ClassAttributeRequiresPhpVersionRuleTest.php
@@ -57,7 +57,7 @@ final class ClassAttributeRequiresPhpVersionRuleTest extends RuleTestCase
 		return new ClassAttributeRequiresPhpVersionRule(
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class),
+				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class), // @phpstan-ignore phpstanApi.classConstant
 				false,
 				true,
 				$this->warnAboutIncompleteVersion,

--- a/tests/Rules/PHPUnit/ClassAttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/ClassAttributeRequiresPhpVersionRuleTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
-use PHPStan\Php\PhpVersion;
+use PHPStan\Php\ConfiguredPhpVersionRangeHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -11,8 +11,6 @@ use PHPStan\Testing\RuleTestCase;
  */
 final class ClassAttributeRequiresPhpVersionRuleTest extends RuleTestCase
 {
-
-	private int $phpVersion = 80500;
 
 	private int $phpunitMajorVersion;
 
@@ -59,7 +57,7 @@ final class ClassAttributeRequiresPhpVersionRuleTest extends RuleTestCase
 		return new ClassAttributeRequiresPhpVersionRule(
 			new AttributeVersionRequirementHelper(
 				$phpunitVersion,
-				new PhpVersion($this->phpVersion),
+				self::getContainer()->getByType(ConfiguredPhpVersionRangeHelper::class),
 				false,
 				true,
 				$this->warnAboutIncompleteVersion,


### PR DESCRIPTION
re-use the logic [extracted into ConfiguredPhpVersionRangeHelper](https://github.com/phpstan/phpstan-src/pull/6014) to make sure expressions 
like `PHP_VERSION_ID < 80200` are handled in the same way as `#[RequiresPhp('<8.2.0')]`

in https://github.com/phpstan/phpstan-src/pull/5972#issuecomment-4885668733 a improvement for the error messaeg is requested.. this will ship in a separate PR
