### PR TITLE
Use sebastian/version-requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"phar-io/version": "^3.2",
-		"phpstan/phpstan": "^2.2.6"
+		"phpstan/phpstan": "^2.2.6",
+		"sebastian/version-requirement": "dev-main"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"
@@ -19,7 +20,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"phpstan/phpstan-deprecation-rules": "^2.0",
 		"phpstan/phpstan-strict-rules": "^2.0",
-		"phpunit/phpunit": "^9.6",
+		"phpunit/phpunit": "^12",
 		"shipmonk/name-collision-detector": "^2.1"
 	},
 	"config": {

--- a/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
+++ b/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
@@ -8,13 +8,12 @@ use PHPStan\Php\ConfiguredPhpVersionRangeHelper;
 use PHPStan\Php\PhpMinorVersionIterator;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use SebastianBergmann\VersionRequirement\InvalidVersionOperatorException;
 use SebastianBergmann\VersionRequirement\InvalidVersionRequirementException;
 use SebastianBergmann\VersionRequirement\Requirement;
 use function count;
-use function is_numeric;
 use function sprintf;
 use function strpos;
-use function substr_count;
 
 final class AttributeVersionRequirementHelper
 {
@@ -66,55 +65,32 @@ final class AttributeVersionRequirementHelper
 				continue;
 			}
 
-			// the following block is mimicing PHPUnit version parsing
-			// see https://github.com/sebastianbergmann/phpunit/blob/43c2cd7b96ee1e800b35e4df23b419a88b53111d/src/Metadata/Version/Requirement.php
-
 			$versionRequirement = $args[0];
 
-			if ($this->warnAboutIncompleteVersion($versionRequirement)) {
-				$errors[] = RuleErrorBuilder::message(
-					sprintf('Version requirement is incomplete.'),
-				)
-					->identifier('phpunit.attributeRequiresPhpVersion')
-					->build();
-			}
-
-			if (
-				!is_numeric($versionRequirement)
-			) {
-				if (!$this->bleedingEdge) {
-					continue;
-				}
-
-				$versionStrings = strpos($attr->getName(), 'RequiresPhpunit') !== false
-					? $this->PHPUnitVersion->getMinMaxVersion()
-					: $this->getAnalyzedPhpVersions();
-				if ($versionStrings === []) {
-					continue;
-				}
-
-				try {
-					// check composer like version constraints, e.g. ^1  or ~2
-					$requirement = Requirement::from($versionRequirement);
-
-					foreach ($versionStrings as $versionString) {
-						if ($requirement->isSatisfiedBy($versionString)) {
-							// one of the versions within range matched, check next attribute
-							continue 2;
-						}
-					}
-				} catch (InvalidVersionRequirementException $e) {
+			try {
+				$requirement = Requirement::from($versionRequirement);
+			} catch (InvalidVersionOperatorException $e) {
+				if ($this->PHPUnitVersion->requiresPhpversionAttributeWithOperator()->yes()) {
 					$errors[] = RuleErrorBuilder::message(
-						sprintf($e->getMessage()),
+						sprintf('Version requirement is missing operator.'),
 					)
 						->identifier('phpunit.attributeRequiresPhpVersion')
 						->build();
-
-					continue;
+				} elseif (
+					$this->deprecationRulesInstalled
+					&& $this->PHPUnitVersion->deprecatesPhpversionAttributeWithoutOperator()->yes()
+				) {
+					$errors[] = RuleErrorBuilder::message(
+						sprintf('Version requirement without operator is deprecated.'),
+					)
+						->identifier('phpunit.attributeRequiresPhpVersion')
+						->build();
 				}
 
+				continue;
+			} catch (InvalidVersionRequirementException $e) {
 				$errors[] = RuleErrorBuilder::message(
-					sprintf('Version requirement will always evaluate to false.'),
+					sprintf($e->getMessage()),
 				)
 					->identifier('phpunit.attributeRequiresPhpVersion')
 					->build();
@@ -122,23 +98,44 @@ final class AttributeVersionRequirementHelper
 				continue;
 			}
 
-			if ($this->PHPUnitVersion->requiresPhpversionAttributeWithOperator()->yes()) {
+			if (!$requirement->isComplete()) {
+				if (!$this->warnAboutIncompleteVersion) {
+					continue;
+				}
+
+				if (!$this->PHPUnitVersion->warnsAboutIncompleteVersion()->yes()) {
+					continue;
+				}
+
 				$errors[] = RuleErrorBuilder::message(
-					sprintf('Version requirement is missing operator.'),
+					sprintf('Version requirement is incomplete.'),
 				)
 					->identifier('phpunit.attributeRequiresPhpVersion')
 					->build();
-			} elseif (
-				$this->deprecationRulesInstalled
-				&& $this->PHPUnitVersion->deprecatesPhpversionAttributeWithoutOperator()->yes()
-			) {
-				$errors[] = RuleErrorBuilder::message(
-					sprintf('Version requirement without operator is deprecated.'),
-				)
-					->identifier('phpunit.attributeRequiresPhpVersion')
-					->build();
+
+				continue;
 			}
+
+			$versionStrings = strpos($attr->getName(), 'RequiresPhpunit') !== false
+				? $this->PHPUnitVersion->getMinMaxVersion()
+				: $this->getAnalyzedPhpVersions();
+			if ($versionStrings === []) {
+				continue;
+			}
+			foreach ($versionStrings as $versionString) {
+				if ($requirement->isSatisfiedBy($versionString)) {
+					// one of the versions within range matched, check next attribute
+					continue 2;
+				}
+			}
+
+			$errors[] = RuleErrorBuilder::message(
+				sprintf('Version requirement will always evaluate to false.'),
+			)
+				->identifier('phpunit.attributeRequiresPhpVersion')
+				->build();
 		}
+
 		return $errors;
 	}
 
@@ -162,24 +159,6 @@ final class AttributeVersionRequirementHelper
 		}
 
 		return [];
-	}
-
-	// see https://github.com/sebastianbergmann/phpunit/issues/6451
-	private function warnAboutIncompleteVersion(string $versionRequirement): bool
-	{
-		if (!$this->bleedingEdge) {
-			return false;
-		}
-
-		if (!$this->warnAboutIncompleteVersion) {
-			return false;
-		}
-
-		if (!$this->PHPUnitVersion->warnsAboutIncompleteVersion()->yes()) {
-			return false;
-		}
-
-		return substr_count($versionRequirement, '.') !== 2;
 	}
 
 }

--- a/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
+++ b/src/Rules/PHPUnit/AttributeVersionRequirementHelper.php
@@ -2,22 +2,19 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
-use PharIo\Version\UnsupportedVersionConstraintException;
-use PharIo\Version\Version;
-use PharIo\Version\VersionConstraintParser;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Reflection\ReflectionAttribute;
 use PHPStan\Php\ConfiguredPhpVersionRangeHelper;
 use PHPStan\Php\PhpMinorVersionIterator;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use SebastianBergmann\VersionRequirement\InvalidVersionRequirementException;
+use SebastianBergmann\VersionRequirement\Requirement;
 use function count;
 use function is_numeric;
-use function preg_match;
 use function sprintf;
 use function strpos;
 use function substr_count;
-use function version_compare;
 
 final class AttributeVersionRequirementHelper
 {
@@ -63,7 +60,6 @@ final class AttributeVersionRequirementHelper
 	public function checkVersionRequirement(array $attributes, Scope $scope): array
 	{
 		$errors = [];
-		$parser = new VersionConstraintParser();
 		foreach ($attributes as $attr) {
 			$args = $attr->getArguments();
 			if (count($args) !== 1) {
@@ -90,43 +86,31 @@ final class AttributeVersionRequirementHelper
 					continue;
 				}
 
-				$pharIoVersions = strpos($attr->getName(), 'RequiresPhpunit') !== false
-					? $this->PHPUnitVersion->getPharIoVersions()
+				$versionStrings = strpos($attr->getName(), 'RequiresPhpunit') !== false
+					? $this->PHPUnitVersion->getMinMaxVersion()
 					: $this->getAnalyzedPhpVersions();
-				if ($pharIoVersions === []) {
+				if ($versionStrings === []) {
 					continue;
 				}
 
 				try {
 					// check composer like version constraints, e.g. ^1  or ~2
-					$testPhpVersionConstraint = $parser->parse($versionRequirement);
+					$requirement = Requirement::from($versionRequirement);
 
-					foreach ($pharIoVersions as $pharIoVersion) {
-						if ($testPhpVersionConstraint->complies($pharIoVersion)) {
+					foreach ($versionStrings as $versionString) {
+						if ($requirement->isSatisfiedBy($versionString)) {
 							// one of the versions within range matched, check next attribute
 							continue 2;
 						}
 					}
-				} catch (UnsupportedVersionConstraintException $e) {
-					// test php-src builtin operators as in version_compare()
-					if (preg_match(self::VERSION_COMPARISON, $versionRequirement, $matches) <= 0) {
-						$errors[] = RuleErrorBuilder::message(
-							sprintf($e->getMessage()),
-						)
-							->identifier('phpunit.attributeRequiresPhpVersion')
-							->build();
+				} catch (InvalidVersionRequirementException $e) {
+					$errors[] = RuleErrorBuilder::message(
+						sprintf($e->getMessage()),
+					)
+						->identifier('phpunit.attributeRequiresPhpVersion')
+						->build();
 
-						continue;
-					}
-
-					$operator = $matches['operator'] !== '' ? $matches['operator'] : '>=';
-
-					foreach ($pharIoVersions as $pharIoVersion) {
-						if (version_compare($pharIoVersion->getVersionString(), $matches['version'], $operator)) {
-							// one of the versions within range matched, check next attribute
-							continue 2;
-						}
-					}
+					continue;
 				}
 
 				$errors[] = RuleErrorBuilder::message(
@@ -159,7 +143,7 @@ final class AttributeVersionRequirementHelper
 	}
 
 	/**
-	 * @return Version[]
+	 * @return list<string>
 	 */
 	private function getAnalyzedPhpVersions(): array
 	{
@@ -172,7 +156,7 @@ final class AttributeVersionRequirementHelper
 				$maxVersion,
 			);
 			foreach ($minorVersionIterator as $phpstanVersion) {
-				$versions[] = new Version($phpstanVersion->getVersionString());
+				$versions[] = $phpstanVersion->getVersionString();
 			}
 			return $versions;
 		}

--- a/src/Rules/PHPUnit/PHPUnitVersion.php
+++ b/src/Rules/PHPUnit/PHPUnitVersion.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Rules\PHPUnit;
 
-use PharIo\Version\Version;
 use PHPStan\TrinaryLogic;
 use function sprintf;
 
@@ -20,17 +19,17 @@ class PHPUnitVersion
 	}
 
 	/**
-	 * @return array{}|array{Version, Version}
+	 * @return array{}|array{string, string}
 	 */
-	public function getPharIoVersions(): array
+	public function getMinMaxVersion(): array
 	{
 		if ($this->majorVersion === null || $this->minorVersion === null) {
 			return [];
 		}
 
 		return [
-			new Version(sprintf('%d.%d.0', $this->majorVersion, $this->minorVersion)),
-			new Version(sprintf('%d.%d.99', $this->majorVersion, $this->minorVersion)),
+			sprintf('%d.%d.0', $this->majorVersion, $this->minorVersion),
+			sprintf('%d.%d.99', $this->majorVersion, $this->minorVersion),
 		];
 	}
 

--- a/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
+++ b/tests/Rules/PHPUnit/AttributeRequiresPhpVersionRuleTest.php
@@ -133,7 +133,7 @@ final class AttributeRequiresPhpVersionRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/requires-php-version-invalid.php'], [
 			[
-				'Version constraint abc is not supported.',
+				'"abc" is not a valid version requirement: expected a version constraint (such as "^8.1", "~8.1.0", or "8.1.*") or a version comparison (such as ">= 8.1.0")',
 				12,
 			],
 		]);


### PR DESCRIPTION
try using https://github.com/sebastianbergmann/version-requirement so we don't need to re-implement phpunit version strategy/fallsbacks

sebastian/version-requirement requires PHP 8.4+, so this PR is more a proof of concept, because we can only merge it when phpstan-phpunit min-php-version-requirements will be 'high enough' to use the lib