### PR TITLE
CI: Fix PHP7.4 build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"php": "^7.4 || ^8.0",
 		"phar-io/version": "^3.2",
 		"phpstan/phpstan": "^2.2.6",
-		"symfony/polyfill-php80": "^1.37"
+		"symfony/polyfill-php80": "^1"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"phar-io/version": "^3.2",
-		"phpstan/phpstan": "^2.2.6",
-		"symfony/polyfill-php80": "^1.37"
+		"phpstan/phpstan": "^2.2.6"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"php": "^7.4 || ^8.0",
 		"phar-io/version": "^3.2",
 		"phpstan/phpstan": "^2.2.6",
-		"symfony/polyfill-php80": "^1"
+		"symfony/polyfill-php80": "^1.37"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"phar-io/version": "^3.2",
-		"phpstan/phpstan": "^2.2.6"
+		"phpstan/phpstan": "^2.2.6",
+		"symfony/polyfill-php80": "^1.37"
 	},
 	"conflict": {
 		"phpunit/phpunit": "<7.0"

--- a/src/Rules/PHPUnit/TestMethodsHelper.php
+++ b/src/Rules/PHPUnit/TestMethodsHelper.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\FileTypeMapper;
 use PHPUnit\Framework\TestCase;
 use function array_key_exists;
+use function strpos;
 use function strtolower;
 
 final class TestMethodsHelper

--- a/src/Rules/PHPUnit/TestMethodsHelper.php
+++ b/src/Rules/PHPUnit/TestMethodsHelper.php
@@ -10,7 +10,6 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\FileTypeMapper;
 use PHPUnit\Framework\TestCase;
 use function array_key_exists;
-use function str_starts_with;
 use function strtolower;
 
 final class TestMethodsHelper
@@ -62,7 +61,7 @@ final class TestMethodsHelper
 				continue;
 			}
 
-			if (str_starts_with(strtolower($reflectionMethod->getName()), 'test')) {
+			if (strpos(strtolower($reflectionMethod->getName()), 'test') === 0) {
 				$testMethods[] = $reflectionMethod;
 				continue;
 			}

--- a/src/Type/PHPUnit/DynamicCallToAssertionIgnoreExtension.php
+++ b/src/Type/PHPUnit/DynamicCallToAssertionIgnoreExtension.php
@@ -8,7 +8,6 @@ use PHPStan\Analyser\IgnoreErrorExtension;
 use PHPStan\Analyser\Scope;
 use PHPUnit\Framework\TestCase;
 use function is_string;
-use function str_starts_with;
 
 final class DynamicCallToAssertionIgnoreExtension implements IgnoreErrorExtension
 {
@@ -33,7 +32,7 @@ final class DynamicCallToAssertionIgnoreExtension implements IgnoreErrorExtensio
 
 		if (
 			!$node->name instanceof Node\Identifier
-			|| !str_starts_with($node->name->name, 'assert')
+			|| strpos($node->name->name, 'assert') !== 0
 		) {
 			return false;
 		}

--- a/src/Type/PHPUnit/DynamicCallToAssertionIgnoreExtension.php
+++ b/src/Type/PHPUnit/DynamicCallToAssertionIgnoreExtension.php
@@ -8,6 +8,7 @@ use PHPStan\Analyser\IgnoreErrorExtension;
 use PHPStan\Analyser\Scope;
 use PHPUnit\Framework\TestCase;
 use function is_string;
+use function strpos;
 
 final class DynamicCallToAssertionIgnoreExtension implements IgnoreErrorExtension
 {


### PR DESCRIPTION
fixes
```
 ------ ---------------------------------------------------------------------- 
  Line   src/Rules/PHPUnit/TestMethodsHelper.php                               
 ------ ---------------------------------------------------------------------- 
  13     Used function str_starts_with not found.                              
         🪪  function.notFound                                                  
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols   
  65     Function str_starts_with not found.                                   
         🪪  function.notFound                                                  
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols   
 ------ ---------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------- 
  Line   src/Type/PHPUnit/DynamicCallToAssertionIgnoreExtension.php            
 ------ ---------------------------------------------------------------------- 
  11     Used function str_starts_with not found.                              
         🪪  function.notFound                                                  
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols   
  36     Function str_starts_with not found.                                   
         🪪  function.notFound                                                  
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols   
 ------ ---------------------------------------------------------------------- 
```